### PR TITLE
fix: unPatch panic when MockValue on nil interface

### DIFF
--- a/mock_var.go
+++ b/mock_var.go
@@ -82,7 +82,11 @@ func (mocker *MockerVar) UnPatch() *MockerVar {
 	defer mocker.lock.Unlock()
 	if mocker.isPatched {
 		mocker.isPatched = false
-		mocker.target.Set(reflect.ValueOf(mocker.origin))
+		if mocker.origin == nil {
+			mocker.target.Set(reflect.Zero(mocker.targetType))
+		} else {
+			mocker.target.Set(reflect.ValueOf(mocker.origin))
+		}
 		removeFromGlobal(mocker)
 	}
 

--- a/mock_var_test.go
+++ b/mock_var_test.go
@@ -17,6 +17,7 @@
 package mockey
 
 import (
+	"fmt"
 	"testing"
 
 	. "github.com/smartystreets/goconvey/convey"
@@ -83,5 +84,23 @@ func TestVarStruct(t *testing.T) {
 			})
 		})
 
+	})
+}
+
+func (t *testStruct) String() string {
+	return t.a
+}
+
+func TestVarStruct2(t *testing.T) {
+	Convey("test mock nil", t, func() {
+		var ttt fmt.Stringer
+		PatchConvey("test mock3", func() {
+			MockValue(&ttt).To(&testStruct{
+				a: "2",
+				b: 3,
+			})
+			So(ttt.(*testStruct).a, ShouldEqual, "2")
+		})
+		So(ttt, ShouldBeNil)
 	})
 }


### PR DESCRIPTION
Change-Id: I2b1c58ccb694bb00d468caf16b839be558fa7276

#### What type of PR is this?
fix: unPatch panic when MockValue on nil interface

#### What this PR does / why we need it (en: English/zh: Chinese):
en: fix bug unPatching panic when using MockValue to mock a interface variable
zh: 修复MockVar对象是nil时，reflect.Value无法直接reset导致unPatch失败的问题

#### Which issue(s) this PR fixes:
[reflect: call of reflect.Value.Set on zero Value](https://github.com/bytedance/mockey/issues/4)
