### PR TITLE
fix: misusage of runtime.sysAlloc may lead to runtime failure in Go 1.19

### DIFF
--- a/internal/monkey/common/mem_above_1_19.go
+++ b/internal/monkey/common/mem_above_1_19.go
@@ -1,0 +1,46 @@
+//go:build go1.19
+// +build go1.19
+
+/*
+ * Copyright 2022 ByteDance Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package common
+
+import (
+	"unsafe"
+
+	"github.com/bytedance/mockey/internal/tool"
+)
+
+/*
+ * This may lead to runtime.ReadMemStats inaccurate
+ * See https://github.com/bytedance/mockey/issues/13
+ */
+func sysAlloc(n uintptr, sysStat *uint64) unsafe.Pointer {
+	tool.DebugPrintf("sysAlloc: go version >= 1.19 use sysAllocOS")
+	return sysAllocOS(n)
+}
+
+func sysFree(v unsafe.Pointer, n uintptr, sysStat *uint64) {
+	tool.DebugPrintf("sysAlloc: go version >= 1.19 use sysFreeOS")
+	sysFreeOS(v, n)
+}
+
+//go:linkname sysAllocOS runtime.sysAllocOS
+func sysAllocOS(n uintptr) unsafe.Pointer
+
+//go:linkname sysFreeOS runtime.sysFreeOS
+func sysFreeOS(v unsafe.Pointer, n uintptr)

--- a/internal/monkey/common/page_test.go
+++ b/internal/monkey/common/page_test.go
@@ -13,31 +13,29 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package common
 
 import (
-	"syscall"
-	"unsafe"
+	"runtime"
+	"testing"
+
+	"github.com/smartystreets/goconvey/convey"
 )
 
-var pageSize = uintptr(syscall.Getpagesize())
+func TestSysAlloc(t *testing.T) {
+	convey.Convey("sysAlloc", t, func() {
+		convey.So(func() {
+			data := AllocatePage()
 
-func PageOf(ptr uintptr) uintptr {
-	return ptr &^ (pageSize - 1)
-}
+			// try write first and last byte of data
+			data[0] = 0
+			data[len(data)-1] = 0
 
-func PageSize() int {
-	return int(pageSize)
-}
+			// try get mem stat
+			m := runtime.MemStats{}
+			runtime.ReadMemStats(&m)
 
-func AllocatePage() []byte {
-	var memStats uint64 = 0
-	addr := sysAlloc(pageSize, &memStats)
-	return BytesOf(uintptr(addr), int(pageSize))
-}
-
-func ReleasePage(mem []byte) {
-	memStats := uint64(cap(mem))
-	sysFree(unsafe.Pointer(PtrOf(mem)), uintptr(cap(mem)), &memStats)
+			ReleasePage(data)
+		}, convey.ShouldNotPanic)
+	})
 }


### PR DESCRIPTION
Fix bug: misusage of runtime.sysAlloc may lead to runtime failure in Go 1.19

#### What type of PR is this?
<!--
fix: misusage of runtime.sysAlloc may lead to runtime failure in Go 1.19+
-->

#### What this PR does / why we need it (en: English/zh: Chinese):
<!--
The description will be attached in Release Notes, 
so please describe it from user-oriented.
-->
en: fix AllocatePage bug that may cause runtime crash in Go 1.19+ 
zh: 修复AllocatePage因为传入的sysStat无法进入runtime的MemStats统计从而riuntime获取内存统计时整个运行时崩溃的问题

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://github.com/bytedance/mockey/issues/13
