### PR TITLE
fix: Panic when GetMethod on nested interface

### DIFF
--- a/utils_test.go
+++ b/utils_test.go
@@ -249,3 +249,145 @@ func TestGetMethod(t *testing.T) {
 		})
 	})
 }
+
+type testNested interface {
+	FooNested()
+}
+type testOuter struct {
+	testNested
+}
+
+type testInner struct {
+	i int
+}
+
+func (testInner) FooNested() {
+	panic("not here")
+}
+
+type testInnerP struct {
+	s string
+}
+
+func (*testInnerP) FooNested() {
+	panic("not here p")
+}
+
+func TestGetNested(t *testing.T) {
+	PatchConvey("TestGetNested", t, func() {
+		PatchConvey("instance implement", func() {
+			var obj testNested
+			PatchConvey("pointer container", func() {
+				obj = &testOuter{testNested: testInner{}}
+				convey.So(func() {
+					Mock(GetMethod(obj, "FooNested")).Return().Build()
+				}, convey.ShouldNotPanic)
+				convey.So(func() {
+					obj.FooNested()
+				}, convey.ShouldNotPanic)
+			})
+			PatchConvey("struct container", func() {
+				obj = testOuter{testNested: testInner{}}
+				convey.So(func() {
+					Mock(GetMethod(obj, "FooNested")).Return().Build()
+				}, convey.ShouldNotPanic)
+				convey.So(func() {
+					obj.FooNested()
+				}, convey.ShouldNotPanic)
+			})
+			PatchConvey("nested container", func() {
+				obj = &testOuter{
+					testNested: testOuter{
+						testNested: &testOuter{
+							testNested: testOuter{
+								testNested: testInner{},
+							},
+						},
+					},
+				}
+				convey.So(func() {
+					Mock(GetMethod(obj, "FooNested")).Return().Build()
+				}, convey.ShouldNotPanic)
+				convey.So(func() {
+					obj.FooNested()
+				}, convey.ShouldNotPanic)
+			})
+		})
+		PatchConvey("instance implement(but pointer field)", func() {
+			var obj testNested
+			PatchConvey("pointer container", func() {
+				obj = &testOuter{testNested: &testInner{}}
+				convey.So(func() {
+					Mock(GetMethod(obj, "FooNested")).Return().Build()
+				}, convey.ShouldNotPanic)
+				convey.So(func() {
+					obj.FooNested()
+				}, convey.ShouldNotPanic)
+			})
+			PatchConvey("struct container", func() {
+				obj = testOuter{testNested: &testInner{}}
+				convey.So(func() {
+					Mock(GetMethod(obj, "FooNested")).Return().Build()
+				}, convey.ShouldNotPanic)
+				convey.So(func() {
+					obj.FooNested()
+				}, convey.ShouldNotPanic)
+			})
+			PatchConvey("nested container", func() {
+				obj = &testOuter{
+					testNested: testOuter{
+						testNested: &testOuter{
+							testNested: testOuter{
+								testNested: &testInner{},
+							},
+						},
+					},
+				}
+				convey.So(func() {
+					Mock(GetMethod(obj, "FooNested")).Return().Build()
+				}, convey.ShouldNotPanic)
+				convey.So(func() {
+					obj.FooNested()
+				}, convey.ShouldNotPanic)
+			})
+		})
+		PatchConvey("pointer implement", func() {
+			var obj testNested
+			PatchConvey("pointer container", func() {
+				obj = &testOuter{testNested: &testInnerP{}}
+				convey.So(func() {
+					Mock(GetMethod(obj, "FooNested")).Return().Build()
+				}, convey.ShouldNotPanic)
+				convey.So(func() {
+					obj.FooNested()
+				}, convey.ShouldNotPanic)
+			})
+			PatchConvey("struct container", func() {
+				obj = testOuter{testNested: &testInnerP{}}
+				convey.So(func() {
+					Mock(GetMethod(obj, "FooNested")).Return().Build()
+				}, convey.ShouldNotPanic)
+				convey.So(func() {
+					obj.FooNested()
+				}, convey.ShouldNotPanic)
+			})
+			PatchConvey("nested container", func() {
+				obj = &testOuter{
+					testNested: testOuter{
+						testNested: &testOuter{
+							testNested: testOuter{
+								testNested: &testInnerP{},
+							},
+						},
+					},
+				}
+				convey.So(func() {
+					Mock(GetMethod(obj, "FooNested")).Return().Build()
+				}, convey.ShouldNotPanic)
+				convey.So(func() {
+					obj.FooNested()
+				}, convey.ShouldNotPanic)
+			})
+		})
+	})
+}


### PR DESCRIPTION
fix panic when `GetMethod` on nested interface

#### What type of PR is this?
fix

#### What this PR does / why we need it (en: English/zh: Chinese):
en: fix panic when `GetMethod` on nested interface
zh: 修复在获取嵌套interface的结构体方法时可能的零值问题

#### Which issue(s) this PR fixes:
#19 
