### PR TITLE
fix: Origin(&ori) NOT works properly with struct methods

### DIFF
--- a/utils_test.go
+++ b/utils_test.go
@@ -258,7 +258,7 @@ type testOuter struct {
 }
 
 type testInner struct {
-	i int
+	_ int
 }
 
 func (testInner) FooNested() {
@@ -266,7 +266,7 @@ func (testInner) FooNested() {
 }
 
 type testInnerP struct {
-	s string
+	_ string
 }
 
 func (*testInnerP) FooNested() {


### PR DESCRIPTION
see https://github.com/bytedance/mockey/issues/15

Change-Id: I1949762b22f78e9b84d9dec8771387f2994e94d4

#### What type of PR is this?
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

fix

#### What this PR does / why we need it (en: English/zh: Chinese):
<!--
The description will be attached in Release Notes, 
so please describe it from user-oriented.
-->
en: fix bugs when using `Origin` on struct method  [https://github.com/bytedance/mockey/issues/15](url)
zh: 修复对struct方法进行`Origin`时会报错的问题

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
https://github.com/bytedance/mockey/issues/15
