### PR TITLE
feat: support sequence return

### DIFF
--- a/mock_condition.go
+++ b/mock_condition.go
@@ -53,9 +53,18 @@ func (m *mockCondition) SetReturn(results ...interface{}) {
 }
 
 func (m *mockCondition) SetReturnForce(results ...interface{}) {
-	tool.CheckReturnType(m.builder.target, results...)
+	getResult := func() []interface{} { return results }
+	if len(results) == 1 {
+		seq, ok := results[0].(SequenceOpt)
+		if ok {
+			getResult = seq.GetNext
+		}
+	}
+
 	targetType := reflect.TypeOf(m.builder.target)
 	m.hook = reflect.MakeFunc(targetType, func(args []reflect.Value) []reflect.Value {
+		results := getResult()
+		tool.CheckReturnType(m.builder.target, results...)
 		valueResults := make([]reflect.Value, 0)
 		for i, result := range results {
 			rValue := reflect.Zero(targetType.Out(i))

--- a/mock_sequence.go
+++ b/mock_sequence.go
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2022 ByteDance Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package mockey
+
+import "github.com/bytedance/mockey/internal/tool"
+
+type SequenceOpt interface {
+	// make sure it is mockey private interface
+	Private
+	// GetNext is used by mockey, don't use it if you don't know what it does
+	GetNext() []interface{}
+}
+
+type sequenceOpt interface {
+	SequenceOpt
+	Times(int) sequenceOpt
+	Then(...interface{}) sequenceOpt
+}
+
+type sequence struct {
+	MockeyPrivate // make sure it does implements mockey SequenceOpt
+	values        []*sequenceValue
+	curV          int // current value
+	curT          int // current value times
+}
+
+type sequenceValue struct {
+	v []interface{}
+	t int
+}
+
+func (s *sequence) GetNext() []interface{} {
+	seqV := s.values[s.curV]
+	s.curT++
+	if s.curT >= seqV.t {
+		s.curT = 0
+		s.curV++
+		if s.curV >= len(s.values) {
+			s.curV = 0
+		}
+	}
+	return seqV.v
+}
+
+func (s *sequence) Then(value ...interface{}) sequenceOpt {
+	s.values = append(s.values, &sequenceValue{
+		v: value,
+		t: 1,
+	})
+	return s
+}
+
+func (s *sequence) Times(t int) sequenceOpt {
+	tool.Assert(t > 0, "return times should more than 0")
+	s.values[len(s.values)-1].t = t
+	return s
+}
+
+func Sequence(value ...interface{}) sequenceOpt {
+	seq := &sequence{}
+	seq.Then(value...)
+	return seq
+}

--- a/mock_sequence_test.go
+++ b/mock_sequence_test.go
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2022 ByteDance Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package mockey
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/smartystreets/goconvey/convey"
+)
+
+func TestSequenceOpt(t *testing.T) {
+	PatchConvey("test sequenceOpt", t, func() {
+		fn := func() (string, int) {
+			fmt.Println("original fn")
+			return "fn: not here", -1
+		}
+
+		tests := []struct {
+			Value1 string
+			Value2 int
+			Times  int
+		}{
+			{"Alice", 2, 3},
+			{"Bob", 3, 1},
+			{"Tom", 4, 1},
+			{"Jerry", 5, 2},
+		}
+
+		seq := Sequence("Admin", 1)
+		for _, r := range tests {
+			seq.Then(r.Value1, r.Value2).Times(r.Times)
+		}
+		Mock(fn).Return(seq).Build()
+
+		for repeat := 3; repeat != 0; repeat-- {
+			v1, v2 := fn()
+			convey.So(v1, convey.ShouldEqual, "Admin")
+			convey.So(v2, convey.ShouldEqual, 1)
+			for _, r := range tests {
+				for rIndex := 0; rIndex < r.Times; rIndex++ {
+					v1, v2 := fn()
+					convey.So(v1, convey.ShouldEqual, r.Value1)
+					convey.So(v2, convey.ShouldEqual, r.Value2)
+				}
+			}
+		}
+	})
+}

--- a/private.go
+++ b/private.go
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2022 ByteDance Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package mockey
+
+// make sure private
+
+type Private interface {
+	private()
+}
+
+type MockeyPrivate struct{}
+
+func (*MockeyPrivate) private() {}


### PR DESCRIPTION
Change-Id: I95036796bdffd559cb713ec3485fa6f064eaf1fa

#### What type of PR is this?
feat: Support sequence returns with one single `Return`

#### What this PR does / why we need it (en: English/zh: Chinese):
<!--
The description will be attached in Release Notes, 
so please describe it from user-oriented.
-->
en: Support sequence returns with one single `Return`
zh: 支持在一个return里序列化设置顺序返回值
