### PR TITLE
feat: suport generics mocking (need go1.18+)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,20 +1,20 @@
 name: Tests
 
-on: [ pull_request ]
+on: [pull_request]
 
 jobs:
   unit-benchmark-test:
     strategy:
       matrix:
         go: ["1.13", "1.14", "1.15", "1.16", "1.17", "1.18", "1.19", "1.20"]
-        os: [ linux ] # should be [ macOS, linux, windows ], but currently we don't have macOS and windows runners
-        arch: [ X64, ARM64 ]
+        os: [linux] # should be [ macOS, linux, windows ], but currently we don't have macOS and windows runners
+        arch: [X64, ARM64]
         exclude:
           - os: Linux
             arch: ARM64
           - os: Windows
             arch: ARM64
-    runs-on: [ "${{ matrix.os }}", "${{ matrix.arch }}" ]
+    runs-on: ["${{ matrix.os }}", "${{ matrix.arch }}"]
     steps:
       - uses: actions/checkout@v3
       - name: Set up Go
@@ -22,6 +22,6 @@ jobs:
         with:
           go-version: ${{ matrix.go }}
       - name: Unit Test
-        run: go test -gcflags="all=-l -N" -covermode=atomic -coverprofile=coverage.out ./...
+        run: MOCKEY_DEBUG=true go test -gcflags="all=-l -N" -covermode=atomic -coverprofile=coverage.out ./...
       - name: Benchmark
         run: go test -bench=. -benchmem -run=none ./...

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,14 @@
 module github.com/bytedance/mockey
 
-go 1.13
+go 1.18
 
 require (
 	github.com/smartystreets/goconvey v1.6.4
 	golang.org/x/arch v0.0.0-20201008161808-52c3e6f60cff
+)
+
+require (
+	github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1 // indirect
+	github.com/jtolds/gls v4.20.0+incompatible // indirect
+	github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d // indirect
 )

--- a/internal/monkey/inst/disasm_amd64.go
+++ b/internal/monkey/inst/disasm_amd64.go
@@ -17,6 +17,9 @@
 package inst
 
 import (
+	"unsafe"
+
+	"github.com/bytedance/mockey/internal/monkey/common"
 	"github.com/bytedance/mockey/internal/tool"
 	"golang.org/x/arch/x86/x86asm"
 )
@@ -34,4 +37,46 @@ func Disassemble(code []byte, required int, checkLen bool) int {
 		pos += inst.Len
 	}
 	return pos
+}
+
+func GetGenericJumpAddr(addr uintptr, maxScan uint64) uintptr {
+	code := common.BytesOf(addr, int(maxScan))
+	var pos uint64
+	var err error
+	var inst x86asm.Inst
+
+	for pos < maxScan {
+		inst, err = x86asm.Decode(code[pos:], 64)
+		tool.Assert(err == nil, err)
+		// if inst.Op == arm64asm.BL {
+		args := []interface{}{inst.Op}
+		for i := range inst.Args {
+			args = append(args, inst.Args[i])
+		}
+		tool.DebugPrintf("%v\t%v\t%v\t%v\t%v\t%v\n", args...)
+
+		if inst.Op == x86asm.CALL {
+			rel := int32(inst.Args[0].(x86asm.Rel))
+			tool.DebugPrintf("found: CALL, raw is: %x, rel: %v\n", inst.String(), rel)
+			return calcAddr(uintptr(unsafe.Pointer(&code[0]))+uintptr(pos+uint64(inst.Len)), rel)
+		}
+		tool.Assert(inst.Op != x86asm.RET, "!!!FOUND RET!!!")
+		pos += uint64(inst.Len)
+	}
+	tool.Assert(false, "CALL op not found")
+	return 0
+}
+
+func calcAddr(from uintptr, rel int32) uintptr {
+	tool.DebugPrintf("calc CALL addr, from: %x(%v) CALL: %x\n", from, from, rel)
+
+	var dest uintptr
+	if rel < 0 {
+		dest = from - uintptr(uint32(-rel))
+	} else {
+		dest = from + uintptr(rel)
+	}
+
+	tool.DebugPrintf("L->H:%v rel: %v from: %x(%v) dest: %x(%v), distance: %v\n", rel > 0, rel, from, from, dest, dest, from-dest)
+	return dest
 }

--- a/internal/monkey/inst/disasm_arm64.go
+++ b/internal/monkey/inst/disasm_arm64.go
@@ -17,10 +17,62 @@
 package inst
 
 import (
+	"unsafe"
+
+	"github.com/bytedance/mockey/internal/monkey/common"
 	"github.com/bytedance/mockey/internal/tool"
+	"golang.org/x/arch/arm64/arm64asm"
 )
 
 func Disassemble(code []byte, required int, checkLen bool) int {
 	tool.Assert(len(code) > required, "function is too short to patch")
 	return required
+}
+
+func GetGenericJumpAddr(addr uintptr, maxScan uint64) uintptr {
+	code := common.BytesOf(addr, int(maxScan))
+	var pos uint64
+	var err error
+	var inst arm64asm.Inst
+
+	for pos < maxScan {
+		inst, err = arm64asm.Decode(code[pos:])
+		tool.Assert(err == nil, err)
+		// if inst.Op == arm64asm.BL {
+		args := []interface{}{inst.Op}
+		for i := range inst.Args {
+			args = append(args, inst.Args[i])
+		}
+		tool.DebugPrintf("%v\t%v\t%v\t%v\t%v\t%v\n", args...)
+
+		if inst.Op == arm64asm.BL {
+			tool.DebugPrintf("found: BL, raw is: %x\n", inst.Enc)
+			return calcAddr(uintptr(unsafe.Pointer(&code[0]))+uintptr(pos), inst.Enc)
+		}
+		pos += uint64(unsafe.Sizeof(inst.Enc))
+		tool.Assert(inst.Op != arm64asm.RET, "!!!FOUND RET!!!")
+	}
+	tool.Assert(false, "BL op not found")
+	return 0
+}
+
+func calcAddr(from uintptr, bl uint32) uintptr {
+	tool.DebugPrintf("calc BL addr, from: %x(%v) bl: %x\n", from, from, bl)
+	offset := bl << 8 >> 8
+	flag := (offset << 9 >> 9) == offset // 是否小于0
+
+	var dest uintptr
+	if flag {
+		// L -> H
+		// (dest - cur) / 4 = offset
+		// dest = cur + offset * 4
+		dest = from + uintptr(offset*4)
+	} else {
+		// H -> L
+		// (cur - dest) / 4 = (0x00ffffff - offset + 1)
+		// dest = cur -  (0x00ffffff - offset + 1) * 4
+		dest = from - uintptr((0x00ffffff-offset+1)*4)
+	}
+	tool.DebugPrintf("2th complement, L->H:%v offset: %x from: %x(%v) dest: %x(%v), distance: %v\n", flag, offset, from, from, dest, dest, from-dest)
+	return dest
 }

--- a/mock.go
+++ b/mock.go
@@ -56,13 +56,18 @@ type MockBuilder struct {
 	filterGoroutine FilterGoroutineType
 	gId             int64
 	unsafe          bool
+	generic         bool
 }
 
-func Mock(target interface{}) *MockBuilder {
+func Mock(target interface{}, opt ...optionFn) *MockBuilder {
 	tool.AssertFunc(target)
 
+	option := resolveOpt(opt...)
+
 	builder := &MockBuilder{
-		target: target,
+		target:  target,
+		unsafe:  option.unsafe,
+		generic: option.generic,
 	}
 	builder.resetCondition()
 	return builder
@@ -71,9 +76,7 @@ func Mock(target interface{}) *MockBuilder {
 // MockUnsafe has the full ability of the Mock function and removes some security restrictions. This is an alternative
 // when the Mock function fails. It may cause some unknown problems, so we recommend using Mock under normal conditions.
 func MockUnsafe(target interface{}) *MockBuilder {
-	builder := Mock(target)
-	builder.unsafe = true
-	return builder
+	return Mock(target, OptionUnsafe)
 }
 
 func (builder *MockBuilder) resetCondition() *MockBuilder {
@@ -299,7 +302,7 @@ func (mocker *Mocker) Patch() *Mocker {
 	if mocker.isPatched {
 		return mocker
 	}
-	mocker.patch = monkey.PatchValue(mocker.target, mocker.hook, reflect.ValueOf(mocker.proxy), mocker.builder.unsafe)
+	mocker.patch = monkey.PatchValue(mocker.target, mocker.hook, reflect.ValueOf(mocker.proxy), mocker.builder.unsafe, mocker.builder.generic)
 	mocker.isPatched = true
 	addToGlobal(mocker)
 

--- a/mock_generics.go
+++ b/mock_generics.go
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2022 ByteDance Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package mockey
+
+func MockGeneric(target interface{}) *MockBuilder {
+	return Mock(target, OptionGeneric)
+}

--- a/mock_generics_test.go
+++ b/mock_generics_test.go
@@ -1,0 +1,65 @@
+//go:build go1.18
+// +build go1.18
+
+/*
+ * Copyright 2022 ByteDance Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package mockey
+
+import (
+	"testing"
+
+	"github.com/smartystreets/goconvey/convey"
+)
+
+func sum[T int | float64](l, r T) T {
+	return l + r
+}
+
+type generic[T int | string] struct {
+	a T
+}
+
+func (g generic[T]) Value() T {
+	return g.a
+}
+
+func (g generic[T]) Value2() T {
+	return g.a + g.a
+}
+
+func TestGeneric(t *testing.T) {
+	PatchConvey("generic", t, func() {
+		PatchConvey("func", func() {
+			MockGeneric(sum[int]).To(func(a, b int) int {
+				return 999
+			}).Build()
+			MockGeneric(sum[float64]).Return(888).Build()
+			convey.So(sum[int](1, 2), convey.ShouldEqual, 999)
+			convey.So(sum[float64](1, 2), convey.ShouldEqual, 888)
+		})
+		PatchConvey("type", func() {
+			Mock((generic[int]).Value, OptionGeneric).Return(999).Build()
+			Mock(GetMethod(generic[string]{}, "Value2"), OptionGeneric).To(func() string {
+				return "mock"
+			}).Build()
+			gi := generic[int]{a: 123}
+			gs := generic[string]{a: "abc"}
+			convey.So(gi.Value(), convey.ShouldEqual, 999)
+			convey.So(gs.Value2(), convey.ShouldEqual, "mock")
+		})
+	})
+}

--- a/option.go
+++ b/option.go
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2022 ByteDance Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package mockey
+
+type option struct {
+	unsafe  bool
+	generic bool
+}
+
+type optionFn func(*option)
+
+var OptionUnsafe optionFn = func(o *option) {
+	o.unsafe = true
+}
+
+var OptionGeneric optionFn = func(o *option) {
+	o.generic = true
+}
+
+func resolveOpt(fn ...optionFn) *option {
+	opt := &option{}
+	for _, f := range fn {
+		f(opt)
+	}
+	return opt
+}


### PR DESCRIPTION
suport generics mocking (need go1.18+)

#### What type of PR is this?
feat

#### What this PR does / why we need it (en: English/zh: Chinese):
en:  support generics like `func sum[T int|float](_,_ T) T` 
zh: 支持泛型mock
