### PR TITLE
fix: check variadic function's cap before calling

### DIFF
--- a/internal/tool/call.go
+++ b/internal/tool/call.go
@@ -16,7 +16,9 @@
 
 package tool
 
-import "reflect"
+import (
+	"reflect"
+)
 
 func ReflectCallWithShiftOne(f reflect.Value, args []reflect.Value, shift bool) []reflect.Value {
 	if shift {
@@ -32,7 +34,13 @@ func ReflectCall(f reflect.Value, args []reflect.Value) []reflect.Value {
 		for i := 0; i < len(args)-1; i++ {
 			newArgs = append(newArgs, args[i])
 		}
-		for i := 0; i < lastArg.Len(); i++ {
+		// FIXME: There are a few cases that lastArgs.cap == 0 but lastArg.len == MAX_INT (arm64).
+		// 		Currently we have no idea how it happens.
+		//      In that case we assume that i should less than lastArg.cap
+		if lastArg.Len() < lastArg.Cap() {
+			DebugPrintf("ReflectCall: broken variadic params: len is %d but cap is %d", lastArg.Len(), lastArg.Cap())
+		}
+		for i := 0; i < lastArg.Len() && i < lastArg.Cap(); i++ {
 			newArgs = append(newArgs, lastArg.Index(i))
 		}
 		return f.Call(newArgs)


### PR DESCRIPTION
Change-Id: Ic9ac689e33484828b27adeca2d342e87c4230362

#### What type of PR is this?
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->
fix

#### What this PR does / why we need it (en: English/zh: Chinese):
<!--
The description will be attached in Release Notes, 
so please describe it from user-oriented.
-->
en:  There are a few cases that `lastArgs.cap == 0` but `lastArg.len == MAX_INT` when calling variadic functions (arm64). Currently we have no idea how it happens. In that case we assume that `lastArgs.len` should less than `lastArg.cap`
zh: 在一些极少情况下mock可变长参数的函数，调用时最后的变长参数slice的len会变得很大，但是cap为0。目前还不清楚为什么slice的len被踩坏了，这里先做一个校验，如果len>cap的话按照cap长度调用mock函数

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
