### PR TITLE
fix: use x19 register(arm64) for BR instruction

### DIFF
--- a/internal/monkey/inst/inst_arm64.go
+++ b/internal/monkey/inst/inst_arm64.go
@@ -24,10 +24,15 @@ func BranchTo(to uintptr) (res []byte) {
 	return
 }
 
+// create a branch into command
+//
+// Go supports passing function arguments from go 1.17 (see https://go.dev/doc/go1.17).
+// We could not use x0~x18 register. As an alternative, we use R19 register (see https://go.googlesource.com/go/+/refs/heads/master/src/cmd/compile/abi-internal.md).
 func BranchInto(to uintptr) (res []byte) {
+	// do not use x0~x18
 	res = append(res, x26MOV(to)...)                     // MOV x26, to // fake
-	res = append(res, []byte{0x4a, 0x03, 0x40, 0xf9}...) // LDR x10, [x26]
-	res = append(res, []byte{0x40, 0x01, 0x1f, 0xd6}...) // BR x10
+	res = append(res, []byte{0x53, 0x03, 0x40, 0xf9}...) // LDR x19, [x26]
+	res = append(res, []byte{0x60, 0x02, 0x1f, 0xd6}...) // BR x19
 	return
 }
 

--- a/mock_test.go
+++ b/mock_test.go
@@ -385,3 +385,39 @@ func TestMockOrigin(t *testing.T) {
 		So((&foo{3}).Foo(), ShouldEqual, 4)
 	})
 }
+
+func TestMultiArgs(t *testing.T) {
+	PatchConvey("multi-arg-result", t, func() {
+		PatchConvey("multi-arg", func() {
+			// Go supports passing function arguments from go 1.17
+			//
+			// Mockey used to use X10 register to make BR instruction in
+			// arm64, which will cause arguments and results get a wrong value
+			//
+			// _0~_15 use x0~x15 register
+			fn := func(_0, _1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15, _16, _17, _18, _19, _20 int64) {
+				fmt.Println(_0, _1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15, _16, _17, _18, _19, _20)
+			}
+			ori := fn
+			Mock(fn).To(func(_0, _1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15, _16, _17, _18, _19, _20 int64) {
+				for _, _x := range []int64{_0, _1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15, _16, _17, _18, _19, _20} {
+					So(_x, ShouldEqual, 0)
+				}
+			}).Origin(&ori).Build()
+			fn(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
+		})
+		PatchConvey("multi-result", func() {
+			fn := func() (_0, _1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15, _16, _17, _18, _19, _20 int64) {
+				return 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
+			}
+			ori := fn
+			Mock(fn).To(func() (_0, _1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15, _16, _17, _18, _19, _20 int64) {
+				return ori()
+			}).Origin(&ori).Build()
+			_0, _1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15, _16, _17, _18, _19, _20 := fn()
+			for _, _x := range []int64{_0, _1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15, _16, _17, _18, _19, _20} {
+				So(_x, ShouldEqual, 0)
+			}
+		})
+	})
+}


### PR DESCRIPTION
Change-Id: Ieb6ca78a9efbe523a9595500845e2c61884e58c3

#### What type of PR is this?
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->
fix

#### What this PR does / why we need it (en: English/zh: Chinese):
<!--
The description will be attached in Release Notes, 
so please describe it from user-oriented.
-->
en: use x19 register(arm64) for BR instruction
zh: arm下使用x19寄存器传参，避免入参值被踩坏

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
