### PR TITLE
fix: got wrong original function addr when generics params or returns…

### DIFF
--- a/internal/monkey/inst/disasm_arm64.go
+++ b/internal/monkey/inst/disasm_arm64.go
@@ -17,12 +17,55 @@
 package inst
 
 import (
+	"reflect"
 	"unsafe"
 
 	"github.com/bytedance/mockey/internal/monkey/common"
 	"github.com/bytedance/mockey/internal/tool"
 	"golang.org/x/arch/arm64/arm64asm"
 )
+
+//go:linkname duffcopy runtime.duffcopy
+func duffcopy()
+
+//go:linkname duffzero runtime.duffzero
+func duffzero()
+
+var duffcopyStart, duffcopyEnd, duffzeroStart, duffzeroEnd uintptr
+
+func init() {
+	duffcopyStart, duffcopyEnd = calcFnAddrRange("duffcopy", duffcopy)
+	duffzeroStart, duffzeroEnd = calcFnAddrRange("duffzero", duffzero)
+}
+
+func calcFnAddrRange(name string, fn func()) (uintptr, uintptr) {
+	v := reflect.ValueOf(fn)
+	var start, end uintptr
+	start = v.Pointer()
+	maxScan := 2000
+	code := common.BytesOf(start, 2000)
+	pos := 0
+	for pos < maxScan {
+		inst, err := arm64asm.Decode(code[pos:])
+		tool.Assert(err == nil, err)
+
+		args := []interface{}{name, inst.Op}
+		for i := range inst.Args {
+			args = append(args, inst.Args[i])
+		}
+		tool.DebugPrintf("init: <%v>\t%v\t%v\t%v\t%v\t%v\t%v\n", args...)
+
+		if inst.Op == arm64asm.RET {
+			end = start + uintptr(pos)
+			tool.DebugPrintf("init: duffcopy(%v,%v)\n", name, start, end)
+			return start, end
+		}
+
+		pos += int(unsafe.Sizeof(inst.Enc))
+	}
+	tool.Assert(false, "%v end not found", name)
+	return 0, 0
+}
 
 func Disassemble(code []byte, required int, checkLen bool) int {
 	tool.Assert(len(code) > required, "function is too short to patch")
@@ -35,25 +78,51 @@ func GetGenericJumpAddr(addr uintptr, maxScan uint64) uintptr {
 	var err error
 	var inst arm64asm.Inst
 
+	allAddrs := []uintptr{}
 	for pos < maxScan {
 		inst, err = arm64asm.Decode(code[pos:])
 		tool.Assert(err == nil, err)
-		// if inst.Op == arm64asm.BL {
 		args := []interface{}{inst.Op}
 		for i := range inst.Args {
 			args = append(args, inst.Args[i])
 		}
 		tool.DebugPrintf("%v\t%v\t%v\t%v\t%v\t%v\n", args...)
 
+		if inst.Op == arm64asm.RET {
+			break
+		}
+
 		if inst.Op == arm64asm.BL {
-			tool.DebugPrintf("found: BL, raw is: %x\n", inst.Enc)
-			return calcAddr(uintptr(unsafe.Pointer(&code[0]))+uintptr(pos), inst.Enc)
+			fnAddr := calcAddr(uintptr(unsafe.Pointer(&code[0]))+uintptr(pos), inst.Enc)
+
+			/*
+				When function argument size is too big, golang will use duff-copy
+				to get better performance. Thus we will see more call-instruction
+				in asm code.
+				For example, assume struct type like this:
+					```
+					type Large15 struct _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _ string}
+					```
+				when we use `Large15` as generic function's argument or return types,
+				the wrapper `function[Large15]` will call `duffcopy` and `duffzero`
+				before passing arguments and after receiving returns.
+
+				Notice that `duff` functions are very special, they are always called
+				in the middle of function body(not at beginning). So we should check
+				the `call` instruction's target address with a range.
+			*/
+
+			isDuffCopy := (fnAddr >= duffcopyStart && fnAddr <= duffcopyEnd)
+			isDuffZero := (fnAddr >= duffzeroStart && fnAddr <= duffzeroEnd)
+			tool.DebugPrintf("found: BL, raw is: %x,  isDuffCopy: %v, isDuffZero: %v fnAddr: %v\n", inst.String(), isDuffCopy, isDuffZero, fnAddr)
+			if !isDuffCopy && !isDuffZero {
+				allAddrs = append(allAddrs, fnAddr)
+			}
 		}
 		pos += uint64(unsafe.Sizeof(inst.Enc))
-		tool.Assert(inst.Op != arm64asm.RET, "!!!FOUND RET!!!")
 	}
-	tool.Assert(false, "BL op not found")
-	return 0
+	tool.Assert(len(allAddrs) == 1, "invalid callAddr: %v", allAddrs)
+	return allAddrs[0]
 }
 
 func calcAddr(from uintptr, bl uint32) uintptr {

--- a/internal/monkey/patch.go
+++ b/internal/monkey/patch.go
@@ -50,7 +50,7 @@ func PatchValue(target, hook, proxy reflect.Value, unsafe, generic bool) *Patch 
 	targetAddr := target.Pointer()
 	if generic {
 		// we assume that generic call/bl op is located in first 200 bytes of codes from targetAddr
-		targetAddr = inst.GetGenericJumpAddr(targetAddr, 200)
+		targetAddr = inst.GetGenericJumpAddr(targetAddr, 10000)
 	}
 	// The first few bytes of the target function code
 	const bufSize = 64

--- a/internal/tool/call.go
+++ b/internal/tool/call.go
@@ -34,13 +34,8 @@ func ReflectCall(f reflect.Value, args []reflect.Value) []reflect.Value {
 		for i := 0; i < len(args)-1; i++ {
 			newArgs = append(newArgs, args[i])
 		}
-		// FIXME: There are a few cases that lastArgs.cap == 0 but lastArg.len == MAX_INT (arm64).
-		// 		Currently we have no idea how it happens.
-		//      In that case we assume that i should less than lastArg.cap
-		if lastArg.Len() < lastArg.Cap() {
-			DebugPrintf("ReflectCall: broken variadic params: len is %d but cap is %d", lastArg.Len(), lastArg.Cap())
-		}
-		for i := 0; i < lastArg.Len() && i < lastArg.Cap(); i++ {
+
+		for i := 0; i < lastArg.Len(); i++ {
 			newArgs = append(newArgs, lastArg.Index(i))
 		}
 		return f.Call(newArgs)

--- a/mock_generics_test.go
+++ b/mock_generics_test.go
@@ -63,3 +63,294 @@ func TestGeneric(t *testing.T) {
 		})
 	})
 }
+
+type Large15[T any] struct {
+	_, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _ T
+}
+
+func TestGenericArg(t *testing.T) {
+	PatchConvey("args", t, func() {
+		GenericArgRunner[uint8]("uint8")
+		GenericArgRunner[uint16]("uint16")
+		GenericArgRunner[uint32]("uint32")
+		GenericArgRunner[uint64]("uint64")
+		GenericArgRunner[Large15[int]]("large15[int]")
+		GenericArgRunner[Large15[Large15[int]]]("Large15[Large15[int]")
+		GenericArgRunner[Large15[Large15[[100]byte]]]("Large15[Large15[[100]byte]")
+	})
+}
+
+func TestGenericRet(t *testing.T) {
+	PatchConvey("rets", t, func() {
+		GenericRetRunner[uint8]("uint8")
+		GenericRetRunner[uint16]("uint16")
+		GenericRetRunner[uint32]("uint32")
+		GenericRetRunner[uint64]("uint64")
+		GenericRetRunner[Large15[int]]("large15[int]")
+		GenericRetRunner[Large15[Large15[int]]]("Large15[Large15[int]")
+		GenericRetRunner[Large15[Large15[[100]byte]]]("Large15[Large15[[100]byte]")
+	})
+}
+
+func TestGenericArgRet(t *testing.T) {
+	PatchConvey("args-rets", t, func() {
+		GenericArgRetRunner[uint8]("uint8")
+		GenericArgRetRunner[uint16]("uint16")
+		GenericArgRetRunner[uint32]("uint32")
+		GenericArgRetRunner[uint64]("uint64")
+		GenericArgRetRunner[Large15[int]]("large15[int]")
+		GenericArgRetRunner[Large15[Large15[int]]]("Large15[Large15[int]")
+		GenericArgRetRunner[Large15[Large15[[100]byte]]]("Large15[Large15[[100]byte]")
+	})
+}
+
+func GenericsArg0[T any]()                                            { panic("0") }
+func GenericsArg1[T any](_ T)                                         { panic("1") }
+func GenericsArg2[T any](_, _ T)                                      { panic("2") }
+func GenericsArg3[T any](_, _, _ T)                                   { panic("3") }
+func GenericsArg4[T any](_, _, _, _ T)                                { panic("4") }
+func GenericsArg5[T any](_, _, _, _, _ T)                             { panic("5") }
+func GenericsArg6[T any](_, _, _, _, _, _ T)                          { panic("6") }
+func GenericsArg7[T any](_, _, _, _, _, _, _ T)                       { panic("7") }
+func GenericsArg8[T any](_, _, _, _, _, _, _, _ T)                    { panic("8") }
+func GenericsArg9[T any](_, _, _, _, _, _, _, _, _ T)                 { panic("9") }
+func GenericsArg10[T any](_, _, _, _, _, _, _, _, _, _ T)             { panic("10") }
+func GenericsArg11[T any](_, _, _, _, _, _, _, _, _, _, _ T)          { panic("11") }
+func GenericsArg12[T any](_, _, _, _, _, _, _, _, _, _, _, _ T)       { panic("12") }
+func GenericsArg13[T any](_, _, _, _, _, _, _, _, _, _, _, _, _ T)    { panic("13") }
+func GenericsArg14[T any](_, _, _, _, _, _, _, _, _, _, _, _, _, _ T) { panic("14") }
+func GenericsArg15[T any](_, _, _, _, _, _, _, _, _, _, _, _, _, _, _ T) {
+	panic("15")
+}
+
+func GenericArgRunner[T any](name string) {
+	// type T = context.Context
+	var arg T
+
+	PatchConvey(name, func() {
+		MockGeneric(GenericsArg0[T]).Return().Build()
+		MockGeneric(GenericsArg1[T]).Return().Build()
+		MockGeneric(GenericsArg2[T]).Return().Build()
+		MockGeneric(GenericsArg3[T]).Return().Build()
+		MockGeneric(GenericsArg4[T]).Return().Build()
+		MockGeneric(GenericsArg5[T]).Return().Build()
+		MockGeneric(GenericsArg6[T]).Return().Build()
+		MockGeneric(GenericsArg7[T]).Return().Build()
+		MockGeneric(GenericsArg8[T]).Return().Build()
+		MockGeneric(GenericsArg9[T]).Return().Build()
+		MockGeneric(GenericsArg10[T]).Return().Build()
+		MockGeneric(GenericsArg11[T]).Return().Build()
+		MockGeneric(GenericsArg12[T]).Return().Build()
+		MockGeneric(GenericsArg13[T]).Return().Build()
+		MockGeneric(GenericsArg14[T]).Return().Build()
+		MockGeneric(GenericsArg15[T]).Return().Build()
+		convey.So(func() { GenericsArg0[T]() }, convey.ShouldNotPanic)
+		convey.So(func() { GenericsArg1(arg) }, convey.ShouldNotPanic)
+		convey.So(func() { GenericsArg2(arg, arg) }, convey.ShouldNotPanic)
+		convey.So(func() { GenericsArg3(arg, arg, arg) }, convey.ShouldNotPanic)
+		convey.So(func() { GenericsArg4(arg, arg, arg, arg) }, convey.ShouldNotPanic)
+		convey.So(func() { GenericsArg5(arg, arg, arg, arg, arg) }, convey.ShouldNotPanic)
+		convey.So(func() { GenericsArg6(arg, arg, arg, arg, arg, arg) }, convey.ShouldNotPanic)
+		convey.So(func() { GenericsArg7(arg, arg, arg, arg, arg, arg, arg) }, convey.ShouldNotPanic)
+		convey.So(func() { GenericsArg8(arg, arg, arg, arg, arg, arg, arg, arg) }, convey.ShouldNotPanic)
+		convey.So(func() { GenericsArg9(arg, arg, arg, arg, arg, arg, arg, arg, arg) }, convey.ShouldNotPanic)
+		convey.So(func() { GenericsArg10(arg, arg, arg, arg, arg, arg, arg, arg, arg, arg) }, convey.ShouldNotPanic)
+		convey.So(func() { GenericsArg11(arg, arg, arg, arg, arg, arg, arg, arg, arg, arg, arg) }, convey.ShouldNotPanic)
+		convey.So(func() { GenericsArg12(arg, arg, arg, arg, arg, arg, arg, arg, arg, arg, arg, arg) }, convey.ShouldNotPanic)
+		convey.So(func() { GenericsArg13(arg, arg, arg, arg, arg, arg, arg, arg, arg, arg, arg, arg, arg) }, convey.ShouldNotPanic)
+		convey.So(func() { GenericsArg14(arg, arg, arg, arg, arg, arg, arg, arg, arg, arg, arg, arg, arg, arg) }, convey.ShouldNotPanic)
+		convey.So(func() { GenericsArg15(arg, arg, arg, arg, arg, arg, arg, arg, arg, arg, arg, arg, arg, arg, arg) }, convey.ShouldNotPanic)
+	})
+
+	convey.So(func() { GenericsArg0[T]() }, convey.ShouldPanic)
+	convey.So(func() { GenericsArg1(arg) }, convey.ShouldPanic)
+	convey.So(func() { GenericsArg2(arg, arg) }, convey.ShouldPanic)
+	convey.So(func() { GenericsArg3(arg, arg, arg) }, convey.ShouldPanic)
+	convey.So(func() { GenericsArg4(arg, arg, arg, arg) }, convey.ShouldPanic)
+	convey.So(func() { GenericsArg5(arg, arg, arg, arg, arg) }, convey.ShouldPanic)
+	convey.So(func() { GenericsArg6(arg, arg, arg, arg, arg, arg) }, convey.ShouldPanic)
+	convey.So(func() { GenericsArg7(arg, arg, arg, arg, arg, arg, arg) }, convey.ShouldPanic)
+	convey.So(func() { GenericsArg8(arg, arg, arg, arg, arg, arg, arg, arg) }, convey.ShouldPanic)
+	convey.So(func() { GenericsArg9(arg, arg, arg, arg, arg, arg, arg, arg, arg) }, convey.ShouldPanic)
+	convey.So(func() { GenericsArg10(arg, arg, arg, arg, arg, arg, arg, arg, arg, arg) }, convey.ShouldPanic)
+	convey.So(func() { GenericsArg11(arg, arg, arg, arg, arg, arg, arg, arg, arg, arg, arg) }, convey.ShouldPanic)
+	convey.So(func() { GenericsArg12(arg, arg, arg, arg, arg, arg, arg, arg, arg, arg, arg, arg) }, convey.ShouldPanic)
+	convey.So(func() { GenericsArg13(arg, arg, arg, arg, arg, arg, arg, arg, arg, arg, arg, arg, arg) }, convey.ShouldPanic)
+	convey.So(func() { GenericsArg14(arg, arg, arg, arg, arg, arg, arg, arg, arg, arg, arg, arg, arg, arg) }, convey.ShouldPanic)
+	convey.So(func() { GenericsArg15(arg, arg, arg, arg, arg, arg, arg, arg, arg, arg, arg, arg, arg, arg, arg) }, convey.ShouldPanic)
+}
+
+func GenericsRet0[T any]()                                            { panic("0") }
+func GenericsRet1[T any]() (_ T)                                      { panic("1") }
+func GenericsRet2[T any]() (_, _ T)                                   { panic("2") }
+func GenericsRet3[T any]() (_, _, _ T)                                { panic("3") }
+func GenericsRet4[T any]() (_, _, _, _ T)                             { panic("4") }
+func GenericsRet5[T any]() (_, _, _, _, _ T)                          { panic("5") }
+func GenericsRet6[T any]() (_, _, _, _, _, _ T)                       { panic("6") }
+func GenericsRet7[T any]() (_, _, _, _, _, _, _ T)                    { panic("7") }
+func GenericsRet8[T any]() (_, _, _, _, _, _, _, _ T)                 { panic("8") }
+func GenericsRet9[T any]() (_, _, _, _, _, _, _, _, _ T)              { panic("9") }
+func GenericsRet10[T any]() (_, _, _, _, _, _, _, _, _, _ T)          { panic("10") }
+func GenericsRet11[T any]() (_, _, _, _, _, _, _, _, _, _, _ T)       { panic("11") }
+func GenericsRet12[T any]() (_, _, _, _, _, _, _, _, _, _, _, _ T)    { panic("12") }
+func GenericsRet13[T any]() (_, _, _, _, _, _, _, _, _, _, _, _, _ T) { panic("13") }
+func GenericsRet14[T any]() (_, _, _, _, _, _, _, _, _, _, _, _, _, _ T) {
+	panic("14")
+}
+
+func GenericsRet15[T any]() (_, _, _, _, _, _, _, _, _, _, _, _, _, _, _ T) {
+	panic("15")
+}
+
+func GenericRetRunner[T any](name string) {
+	var arg T
+	PatchConvey(name, func() {
+		MockGeneric(GenericsRet0[T]).Return().Build()
+		MockGeneric(GenericsRet1[T]).Return(arg).Build()
+		MockGeneric(GenericsRet2[T]).Return(arg, arg).Build()
+		MockGeneric(GenericsRet3[T]).Return(arg, arg, arg).Build()
+		MockGeneric(GenericsRet4[T]).Return(arg, arg, arg, arg).Build()
+		MockGeneric(GenericsRet5[T]).Return(arg, arg, arg, arg, arg).Build()
+		MockGeneric(GenericsRet6[T]).Return(arg, arg, arg, arg, arg, arg).Build()
+		MockGeneric(GenericsRet7[T]).Return(arg, arg, arg, arg, arg, arg, arg).Build()
+		MockGeneric(GenericsRet8[T]).Return(arg, arg, arg, arg, arg, arg, arg, arg).Build()
+		MockGeneric(GenericsRet9[T]).Return(arg, arg, arg, arg, arg, arg, arg, arg, arg).Build()
+		MockGeneric(GenericsRet10[T]).Return(arg, arg, arg, arg, arg, arg, arg, arg, arg, arg).Build()
+		MockGeneric(GenericsRet11[T]).Return(arg, arg, arg, arg, arg, arg, arg, arg, arg, arg, arg).Build()
+		MockGeneric(GenericsRet12[T]).Return(arg, arg, arg, arg, arg, arg, arg, arg, arg, arg, arg, arg).Build()
+		MockGeneric(GenericsRet13[T]).Return(arg, arg, arg, arg, arg, arg, arg, arg, arg, arg, arg, arg, arg).Build()
+		MockGeneric(GenericsRet14[T]).Return(arg, arg, arg, arg, arg, arg, arg, arg, arg, arg, arg, arg, arg, arg).Build()
+		MockGeneric(GenericsRet15[T]).Return(arg, arg, arg, arg, arg, arg, arg, arg, arg, arg, arg, arg, arg, arg, arg).Build()
+		convey.So(func() { GenericsRet0[T]() }, convey.ShouldNotPanic)
+		convey.So(func() { GenericsRet1[T]() }, convey.ShouldNotPanic)
+		convey.So(func() { GenericsRet2[T]() }, convey.ShouldNotPanic)
+		convey.So(func() { GenericsRet3[T]() }, convey.ShouldNotPanic)
+		convey.So(func() { GenericsRet4[T]() }, convey.ShouldNotPanic)
+		convey.So(func() { GenericsRet5[T]() }, convey.ShouldNotPanic)
+		convey.So(func() { GenericsRet6[T]() }, convey.ShouldNotPanic)
+		convey.So(func() { GenericsRet7[T]() }, convey.ShouldNotPanic)
+		convey.So(func() { GenericsRet8[T]() }, convey.ShouldNotPanic)
+		convey.So(func() { GenericsRet9[T]() }, convey.ShouldNotPanic)
+		convey.So(func() { GenericsRet10[T]() }, convey.ShouldNotPanic)
+		convey.So(func() { GenericsRet11[T]() }, convey.ShouldNotPanic)
+		convey.So(func() { GenericsRet12[T]() }, convey.ShouldNotPanic)
+		convey.So(func() { GenericsRet13[T]() }, convey.ShouldNotPanic)
+		convey.So(func() { GenericsRet14[T]() }, convey.ShouldNotPanic)
+		convey.So(func() { GenericsRet15[T]() }, convey.ShouldNotPanic)
+	})
+
+	convey.So(func() { GenericsRet0[T]() }, convey.ShouldPanic)
+	convey.So(func() { GenericsRet1[T]() }, convey.ShouldPanic)
+	convey.So(func() { GenericsRet2[T]() }, convey.ShouldPanic)
+	convey.So(func() { GenericsRet3[T]() }, convey.ShouldPanic)
+	convey.So(func() { GenericsRet4[T]() }, convey.ShouldPanic)
+	convey.So(func() { GenericsRet5[T]() }, convey.ShouldPanic)
+	convey.So(func() { GenericsRet6[T]() }, convey.ShouldPanic)
+	convey.So(func() { GenericsRet7[T]() }, convey.ShouldPanic)
+	convey.So(func() { GenericsRet8[T]() }, convey.ShouldPanic)
+	convey.So(func() { GenericsRet9[T]() }, convey.ShouldPanic)
+	convey.So(func() { GenericsRet10[T]() }, convey.ShouldPanic)
+	convey.So(func() { GenericsRet11[T]() }, convey.ShouldPanic)
+	convey.So(func() { GenericsRet12[T]() }, convey.ShouldPanic)
+	convey.So(func() { GenericsRet13[T]() }, convey.ShouldPanic)
+	convey.So(func() { GenericsRet14[T]() }, convey.ShouldPanic)
+	convey.So(func() { GenericsRet15[T]() }, convey.ShouldPanic)
+}
+
+func GenericsArgRet0[T any]()                                        { panic("0") }
+func GenericsArgRet1[T any](_ T) (_ T)                               { panic("1") }
+func GenericsArgRet2[T any](_, _ T) (_, _ T)                         { panic("2") }
+func GenericsArgRet3[T any](_, _, _ T) (_, _, _ T)                   { panic("3") }
+func GenericsArgRet4[T any](_, _, _, _ T) (_, _, _, _ T)             { panic("4") }
+func GenericsArgRet5[T any](_, _, _, _, _ T) (_, _, _, _, _ T)       { panic("5") }
+func GenericsArgRet6[T any](_, _, _, _, _, _ T) (_, _, _, _, _, _ T) { panic("6") }
+func GenericsArgRet7[T any](_, _, _, _, _, _, _ T) (_, _, _, _, _, _, _ T) {
+	panic("7")
+}
+
+func GenericsArgRet8[T any](_, _, _, _, _, _, _, _ T) (_, _, _, _, _, _, _, _ T) {
+	panic("8")
+}
+
+func GenericsArgRet9[T any](_, _, _, _, _, _, _, _, _ T) (_, _, _, _, _, _, _, _, _ T) {
+	panic("9")
+}
+
+func GenericsArgRet10[T any](_, _, _, _, _, _, _, _, _, _ T) (_, _, _, _, _, _, _, _, _, _ T) {
+	panic("10")
+}
+
+func GenericsArgRet11[T any](_, _, _, _, _, _, _, _, _, _, _ T) (_, _, _, _, _, _, _, _, _, _, _ T) {
+	panic("11")
+}
+
+func GenericsArgRet12[T any](_, _, _, _, _, _, _, _, _, _, _, _ T) (_, _, _, _, _, _, _, _, _, _, _, _ T) {
+	panic("12")
+}
+
+func GenericsArgRet13[T any](_, _, _, _, _, _, _, _, _, _, _, _, _ T) (_, _, _, _, _, _, _, _, _, _, _, _, _ T) {
+	panic("13")
+}
+
+func GenericsArgRet14[T any](_, _, _, _, _, _, _, _, _, _, _, _, _, _ T) (_, _, _, _, _, _, _, _, _, _, _, _, _, _ T) {
+	panic("14")
+}
+
+func GenericsArgRet15[T any](_, _, _, _, _, _, _, _, _, _, _, _, _, _, _ T) (_, _, _, _, _, _, _, _, _, _, _, _, _, _, _ T) {
+	panic("15")
+}
+
+func GenericArgRetRunner[T any](name string) {
+	var arg T
+	PatchConvey(name, func() {
+		MockGeneric(GenericsArgRet0[T]).Return().Build()
+		MockGeneric(GenericsArgRet1[T]).Return(arg).Build()
+		MockGeneric(GenericsArgRet2[T]).Return(arg, arg).Build()
+		MockGeneric(GenericsArgRet3[T]).Return(arg, arg, arg).Build()
+		MockGeneric(GenericsArgRet4[T]).Return(arg, arg, arg, arg).Build()
+		MockGeneric(GenericsArgRet5[T]).Return(arg, arg, arg, arg, arg).Build()
+		MockGeneric(GenericsArgRet6[T]).Return(arg, arg, arg, arg, arg, arg).Build()
+		MockGeneric(GenericsArgRet7[T]).Return(arg, arg, arg, arg, arg, arg, arg).Build()
+		MockGeneric(GenericsArgRet8[T]).Return(arg, arg, arg, arg, arg, arg, arg, arg).Build()
+		MockGeneric(GenericsArgRet9[T]).Return(arg, arg, arg, arg, arg, arg, arg, arg, arg).Build()
+		MockGeneric(GenericsArgRet10[T]).Return(arg, arg, arg, arg, arg, arg, arg, arg, arg, arg).Build()
+		MockGeneric(GenericsArgRet11[T]).Return(arg, arg, arg, arg, arg, arg, arg, arg, arg, arg, arg).Build()
+		MockGeneric(GenericsArgRet12[T]).Return(arg, arg, arg, arg, arg, arg, arg, arg, arg, arg, arg, arg).Build()
+		MockGeneric(GenericsArgRet13[T]).Return(arg, arg, arg, arg, arg, arg, arg, arg, arg, arg, arg, arg, arg).Build()
+		MockGeneric(GenericsArgRet14[T]).Return(arg, arg, arg, arg, arg, arg, arg, arg, arg, arg, arg, arg, arg, arg).Build()
+		MockGeneric(GenericsArgRet15[T]).Return(arg, arg, arg, arg, arg, arg, arg, arg, arg, arg, arg, arg, arg, arg, arg).Build()
+		convey.So(func() { GenericsArgRet0[T]() }, convey.ShouldNotPanic)
+		convey.So(func() { GenericsArgRet1(arg) }, convey.ShouldNotPanic)
+		convey.So(func() { GenericsArgRet2(arg, arg) }, convey.ShouldNotPanic)
+		convey.So(func() { GenericsArgRet3(arg, arg, arg) }, convey.ShouldNotPanic)
+		convey.So(func() { GenericsArgRet4(arg, arg, arg, arg) }, convey.ShouldNotPanic)
+		convey.So(func() { GenericsArgRet5(arg, arg, arg, arg, arg) }, convey.ShouldNotPanic)
+		convey.So(func() { GenericsArgRet6(arg, arg, arg, arg, arg, arg) }, convey.ShouldNotPanic)
+		convey.So(func() { GenericsArgRet7(arg, arg, arg, arg, arg, arg, arg) }, convey.ShouldNotPanic)
+		convey.So(func() { GenericsArgRet8(arg, arg, arg, arg, arg, arg, arg, arg) }, convey.ShouldNotPanic)
+		convey.So(func() { GenericsArgRet9(arg, arg, arg, arg, arg, arg, arg, arg, arg) }, convey.ShouldNotPanic)
+		convey.So(func() { GenericsArgRet10(arg, arg, arg, arg, arg, arg, arg, arg, arg, arg) }, convey.ShouldNotPanic)
+		convey.So(func() { GenericsArgRet11(arg, arg, arg, arg, arg, arg, arg, arg, arg, arg, arg) }, convey.ShouldNotPanic)
+		convey.So(func() { GenericsArgRet12(arg, arg, arg, arg, arg, arg, arg, arg, arg, arg, arg, arg) }, convey.ShouldNotPanic)
+		convey.So(func() { GenericsArgRet13(arg, arg, arg, arg, arg, arg, arg, arg, arg, arg, arg, arg, arg) }, convey.ShouldNotPanic)
+		convey.So(func() { GenericsArgRet14(arg, arg, arg, arg, arg, arg, arg, arg, arg, arg, arg, arg, arg, arg) }, convey.ShouldNotPanic)
+		convey.So(func() { GenericsArgRet15(arg, arg, arg, arg, arg, arg, arg, arg, arg, arg, arg, arg, arg, arg, arg) }, convey.ShouldNotPanic)
+	})
+
+	convey.So(func() { GenericsArgRet0[T]() }, convey.ShouldPanic)
+	convey.So(func() { GenericsArgRet1(arg) }, convey.ShouldPanic)
+	convey.So(func() { GenericsArgRet2(arg, arg) }, convey.ShouldPanic)
+	convey.So(func() { GenericsArgRet3(arg, arg, arg) }, convey.ShouldPanic)
+	convey.So(func() { GenericsArgRet4(arg, arg, arg, arg) }, convey.ShouldPanic)
+	convey.So(func() { GenericsArgRet5(arg, arg, arg, arg, arg) }, convey.ShouldPanic)
+	convey.So(func() { GenericsArgRet6(arg, arg, arg, arg, arg, arg) }, convey.ShouldPanic)
+	convey.So(func() { GenericsArgRet7(arg, arg, arg, arg, arg, arg, arg) }, convey.ShouldPanic)
+	convey.So(func() { GenericsArgRet8(arg, arg, arg, arg, arg, arg, arg, arg) }, convey.ShouldPanic)
+	convey.So(func() { GenericsArgRet9(arg, arg, arg, arg, arg, arg, arg, arg, arg) }, convey.ShouldPanic)
+	convey.So(func() { GenericsArgRet10(arg, arg, arg, arg, arg, arg, arg, arg, arg, arg) }, convey.ShouldPanic)
+	convey.So(func() { GenericsArgRet11(arg, arg, arg, arg, arg, arg, arg, arg, arg, arg, arg) }, convey.ShouldPanic)
+	convey.So(func() { GenericsArgRet12(arg, arg, arg, arg, arg, arg, arg, arg, arg, arg, arg, arg) }, convey.ShouldPanic)
+	convey.So(func() { GenericsArgRet13(arg, arg, arg, arg, arg, arg, arg, arg, arg, arg, arg, arg, arg) }, convey.ShouldPanic)
+	convey.So(func() { GenericsArgRet14(arg, arg, arg, arg, arg, arg, arg, arg, arg, arg, arg, arg, arg, arg) }, convey.ShouldPanic)
+	convey.So(func() { GenericsArg15(arg, arg, arg, arg, arg, arg, arg, arg, arg, arg, arg, arg, arg, arg, arg) }, convey.ShouldPanic)
+}


### PR DESCRIPTION
… size are too big

Change-Id: I131a8e7cfda5cf67ff272c81748a30bb12ea87f3

#### What type of PR is this?
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->
fix

#### What this PR does / why we need it (en: English/zh: Chinese):
<!--
The description will be attached in Release Notes, 
so please describe it from user-oriented.
-->
en:  Fix bug when generic functions's params are too large.
zh: 修复模板函数参数过大导致的mock不正确的问题

