### PR TITLE
fix: wrong parameter value when using To/When on generic functions

### DIFF
--- a/internal/monkey/fn/copy_darwin.go
+++ b/internal/monkey/fn/copy_darwin.go
@@ -31,7 +31,7 @@ func Copy(targetPtr, oriFn interface{}) {
 	targetType := targetVal.Type().Elem()
 	tool.Assert(targetType.Kind() == reflect.Func, "'%v' is not a function pointer", targetPtr)
 	oriVal := reflect.ValueOf(oriFn)
-	tool.Assert(tool.CheckFuncArgs(targetType, oriVal.Type(), 0), "target and ori not match")
+	tool.Assert(tool.CheckFuncArgs(targetType, oriVal.Type(), 0, 0), "target and ori not match")
 
 	oriAddr := oriVal.Pointer()
 	tool.DebugPrintf("Copy: copy start for %v\n", runtime.FuncForPC(oriAddr).Name())

--- a/internal/monkey/patch.go
+++ b/internal/monkey/patch.go
@@ -44,8 +44,6 @@ func (p *Patch) Unpatch() {
 func PatchValue(target, hook, proxy reflect.Value, unsafe, generic bool) *Patch {
 	tool.Assert(hook.Kind() == reflect.Func, "'%s' is not a function", hook.Kind())
 	tool.Assert(proxy.Kind() == reflect.Ptr, "'%v' is not a function pointer", proxy.Kind())
-	tool.Assert(hook.Type() == target.Type(), "'%v' and '%s' mismatch", hook.Type(), target.Type())
-	tool.Assert(proxy.Elem().Type() == target.Type(), "'*%v' and '%s' mismatch", proxy.Elem().Type(), target.Type())
 
 	targetAddr := target.Pointer()
 	if generic {

--- a/internal/tool/call.go
+++ b/internal/tool/call.go
@@ -20,13 +20,6 @@ import (
 	"reflect"
 )
 
-func ReflectCallWithShiftOne(f reflect.Value, args []reflect.Value, shift bool) []reflect.Value {
-	if shift {
-		return ReflectCall(f, args[1:])
-	}
-	return ReflectCall(f, args)
-}
-
 func ReflectCall(f reflect.Value, args []reflect.Value) []reflect.Value {
 	if f.Type().IsVariadic() {
 		newArgs := make([]reflect.Value, 0)

--- a/internal/tool/check.go
+++ b/internal/tool/check.go
@@ -32,10 +32,10 @@ func CheckReturnType(fn interface{}, results ...interface{}) {
 	}
 }
 
-func CheckFuncArgs(a, b reflect.Type, shift int) bool {
-	if a.NumIn() == b.NumIn()+shift {
-		for i := shift; i < a.NumIn(); i++ {
-			if a.In(i) != b.In(i-shift) {
+func CheckFuncArgs(a, b reflect.Type, shiftA, shiftB int) bool {
+	if a.NumIn()-shiftA == b.NumIn()-shiftB {
+		for indexA, indexB := shiftA, shiftB; indexA < a.NumIn(); indexA, indexB = indexA+1, indexB+1 {
+			if a.In(indexA) != b.In(indexB) {
 				return false
 			}
 		}


### PR DESCRIPTION
#### What type of PR is this?
fix

#### What this PR does / why we need it (en: English/zh: Chinese):
<!--
The description will be attached in Release Notes, 
so please describe it from user-oriented.
-->
en: fix bug that 'When/To' hook's input value be all incorrect when mock generic functions 
zh: 修复在mock泛型函数时使用When/To，目标函数的入参值会全部变错误的问题

