### PR TITLE
fix: do not panic when user forget to add gcflags

### DIFF
--- a/internal/tool/check_gcflags.go
+++ b/internal/tool/check_gcflags.go
@@ -27,8 +27,8 @@ func init() {
 
 func checkGCflags() int {
 	if flag := os.Getenv("MOCKEY_CHECK_GCFLAGS"); flag != "false" && !IsGCFlagsSet() {
-		panic(`
-Mockey init failed, did you forget to add -gcflags="all=-N -l" ?
+		println(`
+Mockey check failed, please add -gcflags="all=-N -l".
 (Set env MOCKEY_CHECK_GCFLAGS=false to disable gcflags check) 
 		`)
 	}


### PR DESCRIPTION
Change-Id: I34505cea2eb96cddff5b7da71f918ca2d21c134d

#### What type of PR is this?
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->
fix

#### What this PR does / why we need it (en: English/zh: Chinese):
<!--
The description will be attached in Release Notes, 
so please describe it from user-oriented.
-->
en: do not panic when user forget to add gcflags
zh: 检查gcflags失败的情况不panic，改为打err日志

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
