### PR TITLE
fix: panic when write code cross-page

### DIFF
--- a/internal/monkey/mem/write_test.go
+++ b/internal/monkey/mem/write_test.go
@@ -1,0 +1,61 @@
+package mem
+
+// Copyright 2023 2022 ByteDance Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import (
+	"testing"
+
+	"github.com/bytedance/mockey/internal/monkey/common"
+	"github.com/bytedance/mockey/internal/tool"
+)
+
+func TestWrite(t *testing.T) {
+	data := make([]byte, common.PageSize()*3)
+	target := uintptr(common.PageSize() / 2)
+
+	expected := [][2]uintptr{
+		{target, uintptr(common.PageSize())},
+		{uintptr(common.PageSize()), uintptr(common.PageSize()) * 2},
+		{uintptr(common.PageSize() * 2), uintptr(common.PageSize()) * 3},
+		{uintptr(common.PageSize() * 3), target + uintptr(len(data))},
+	}
+
+	begin := target
+	end := target + uintptr(len(data))
+	index := 0
+	for begin < end {
+		if common.PageOf(begin) < common.PageOf(end) {
+			nextPage := common.PageOf(begin) + uintptr(common.PageSize())
+			buf := data[:nextPage-begin]
+			data = data[nextPage-begin:]
+
+			// err := Write(begin, buf)
+			// tool.Assert(err == nil, err)
+			tool.Assert(begin == expected[index][0], index, begin, expected[index][0])
+			tool.Assert(begin+uintptr(len(buf)) == expected[index][1], index, begin+uintptr(len(buf)), expected[index][1])
+
+			begin += uintptr(len(buf))
+			index += 1
+			continue
+		}
+
+		// err := Write(begin, data)
+		// tool.Assert(err == nil, err)
+		tool.Assert(begin == expected[index][0], index, begin, expected[index][0])
+		tool.Assert(begin+uintptr(len(data)) == expected[index][1], index, begin+uintptr(len(data)), expected[index][1])
+
+		break
+	}
+}


### PR DESCRIPTION
Change-Id: I65f95f8be6c7f77f903efde5877d42856473c306

#### What type of PR is this?
fix

#### What this PR does / why we need it (en: English/zh: Chinese):
<!--
The description will be attached in Release Notes, 
so please describe it from user-oriented.
-->
en: Change page write to one by one to avoid cross-page writing failure
zh: 写page时改成一个一个写，避免跨page写入时因权限问题导致的调用失败

