### PR TITLE
fix: GetMethod on nil pointer

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -54,6 +54,10 @@ func getMethod(val reflect.Value, methodName string, opts *methodOption) (method
 	if kind == reflect.Ptr || kind == reflect.Interface {
 		val = val.Elem()
 		if !val.IsValid() {
+			// if is nil pointer but with type, try get method from pointer type
+			if m, ok := typ.MethodByName(methodName); ok {
+				return m.Func, true
+			}
 			return
 		}
 		typ = val.Type()

--- a/utils_test.go
+++ b/utils_test.go
@@ -462,3 +462,30 @@ func TestGetMethod_Unexported(t *testing.T) {
 		})
 	})
 }
+
+type testNilPointerInner struct {
+	_ int
+}
+
+func (t *testNilPointerInner) Foo() string {
+	return "not here"
+}
+
+type testNilPointerOuter struct {
+	*testNilPointerInner
+}
+
+func TestGetMethod_NilPointer(t *testing.T) {
+	PatchConvey("TestGetMethod_NilPointer", t, func() {
+		PatchConvey("nil pointer", func() {
+			var obj *testNilPointerInner
+			Mock(GetMethod(obj, "Foo")).Return("nil pointer").Build()
+			convey.So(obj.Foo(), convey.ShouldEqual, "nil pointer")
+		})
+		PatchConvey("nested nil pointer", func() {
+			var obj = &testNilPointerOuter{}
+			Mock(GetMethod(obj, "Foo")).Return("nested pointer").Build()
+			convey.So(obj.Foo(), convey.ShouldEqual, "nested pointer")
+		})
+	})
+}


### PR DESCRIPTION
Change-Id: I7b3159be32d39b02311dd7a352ab4dc5fb9f86db

#### What type of PR is this?
fix

#### What this PR does / why we need it (en: English/zh: Chinese):
en: Fix the issue where the GetMethod method fails to retrieve the method when used on a nil pointer to a struct.
zh: 修复在对结构体的空指针使用GetMethod方法时取不到方法的问题
