### PR TITLE
feat: make testing.T-scoped mock easier to set up

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ func TestWin(t *testing.T) {
     - Basic
         - Simple / generic / variadic function or method (value or pointer receiver)
         - Supporting hook function
-        - Supporting `PatchConvey` and `PatchRun` (automatically release mocks after each test case)
+        - Supporting `PatchConvey`, `PatchRun`, BuildT (automatically release mocks after each test case)
         - Providing `GetMethod` to handle special cases (e.g., unexported types, unexported method, and methods in nested structs)
     - Advanced
         - Interface mocking (experimental feature)
@@ -392,6 +392,63 @@ func TestXXX(t *testing.T) {
 	}
 }
 ```
+
+### Supporting `BuildT`
+
+`BuildT` binds each mock's lifecycle to a `*testing.T` (or any value satisfying the `mockey.TestingT` interface), so cleanup runs automatically when the test or subtest exits, with no `defer` and no goconvey dependency. It's the most idiomatic option for tests that don't use goconvey, and works in subtests created via `t.Run`.
+
+`BuildT` example as follows:
+```go
+package main_test
+
+import (
+	"testing"
+
+	. "github.com/bytedance/mockey"
+)
+
+func Foo(in string) string {
+	return "ori:" + in
+}
+
+func Bar() string {
+	return "ori:bar"
+}
+
+func TestXXX(t *testing.T) {
+	Mock(Foo).Return("MOCKED-1!").BuildT(t)
+	if got := Foo("anything"); got != "MOCKED-1!" {
+		t.Errorf("expected 'MOCKED-1!', got '%s'", got)
+	}
+
+	t.Run("subtest A", func(t *testing.T) {
+		// Each subtest can register its own mocks bound to its own *testing.T.
+		// Mock a different target than the parent's; mockey panics on
+		// re-mocking the same target without Release first.
+		Mock(Bar).Return("subtest-A").BuildT(t)
+		if got := Bar(); got != "subtest-A" {
+			t.Errorf("expected 'subtest-A', got '%s'", got)
+		}
+		// Parent's mock on Foo is still active inside the subtest:
+		if got := Foo("anything"); got != "MOCKED-1!" {
+			t.Errorf("expected 'MOCKED-1!', got '%s'", got)
+		}
+	})
+	// subtest A's mock on Bar is cleaned up; parent's mock on Foo is still active.
+
+	// After TestXXX returns, all mocks registered via BuildT(t) are released.
+}
+```
+
+`BuildT` accepts any value that satisfies the `mockey.TestingT` interface:
+
+```go
+type TestingT interface {
+	Cleanup(func())
+}
+```
+
+`*testing.T`, `*testing.B`, and `*testing.F` all satisfy it, so `BuildT` works in unit tests, benchmarks, and fuzz tests. `BuildT` can also be combined with `PatchRun` or `PatchConvey`: the inner scope's cleanup fires first, and the outer `t.Cleanup` is then a safe no-op (`UnPatch` is idempotent).
 
 ### Providing `GetMethod` to handle special cases
 In special cases where direct mocking is not possible or not effective, you can use `GetMethod` to get the corresponding method before mocking. Please ensure that the passed object is not nil.

--- a/README_cn.md
+++ b/README_cn.md
@@ -76,6 +76,7 @@ func TestWin(t *testing.T) {
     - 简单/泛型/可变参数函数或方法（值或指针接收器）
     - 支持钩子函数
     - 支持`PatchConvey`和`PatchRun`（每个测试用例后自动释放 mock）
+    - 支持`BuildT`（将 mock 生命周期绑定到`*testing.T`）
     - 提供`GetMethod`处理特殊情况（如未导出类型、未导出方法和嵌套结构体中的方法）
   - 高级功能
     - 接口 mock（实验特性）
@@ -299,7 +300,7 @@ func main() {
 ### 支持`PatchConvey`和`PatchRun`
 > 从 v1.4.1 版本开始支持 `PatchRun`
 
-`PatchConvey`和`PatchRun`都是用于管理 mock 生命周期的工具，它们会在测试用例或函数执行完成后自动释放 mock，从而免去`defer`的苦恼。`PatchConvey`和`PatchRun`都支持嵌套使用，每层只会释放自己内部的 mock。
+`PatchConvey`和`PatchRun`都是用于管理 mock 生命周期的工具，它们会在测试用例或函数执行完成后自动释放 mock，从而免去`defer`的苦恼。它们都支持嵌套使用，每层只会释放自己内部的 mock。
 
 适用场景对比：
 - 当您需要使用 goconvey 框架的断言功能和测试组织能力时，推荐使用`PatchConvey`；嵌套`PatchConvey`的执行顺序和`Convey`一致，请参考 goconvey 相关[文档](https://github.com/smartystreets/goconvey/wiki/Execution-order)
@@ -390,6 +391,62 @@ func TestXXX(t *testing.T) {
 }
 
 ```
+
+### 支持`BuildT`
+
+`BuildT`将每个 mock 的生命周期绑定到`*testing.T`（或任何实现了`mockey.TestingT`接口的值），mock 会在测试或子测试结束时自动清理，既不需要`defer`，也不依赖 goconvey。对于不使用 goconvey 的测试，这是最符合 Go 习惯的方式，并且兼容通过`t.Run`创建的子测试。
+
+`BuildT`示例如下：
+```go
+package main_test
+
+import (
+	"testing"
+
+	. "github.com/bytedance/mockey"
+)
+
+func Foo(in string) string {
+	return "ori:" + in
+}
+
+func Bar() string {
+	return "ori:bar"
+}
+
+func TestXXX(t *testing.T) {
+	Mock(Foo).Return("MOCKED-1!").BuildT(t)
+	if got := Foo("anything"); got != "MOCKED-1!" {
+		t.Errorf("expected 'MOCKED-1!', got '%s'", got)
+	}
+
+	t.Run("subtest A", func(t *testing.T) {
+		// 每个子测试可以注册自己绑定到对应 *testing.T 的 mock。
+		// 在子测试中 mock 与父测试不同的目标；mockey 在没有先 Release 的情况下重复 mock 同一个目标会 panic。
+		Mock(Bar).Return("subtest-A").BuildT(t)
+		if got := Bar(); got != "subtest-A" {
+			t.Errorf("expected 'subtest-A', got '%s'", got)
+		}
+		// 在子测试内部，父测试对 Foo 的 mock 仍然生效：
+		if got := Foo("anything"); got != "MOCKED-1!" {
+			t.Errorf("expected 'MOCKED-1!', got '%s'", got)
+		}
+	})
+	// 子测试 A 对 Bar 的 mock 已经被清理；父测试对 Foo 的 mock 仍然生效。
+
+	// TestXXX 返回时，所有通过 BuildT(t) 注册的 mock 都会被释放
+}
+```
+
+`BuildT` 接收任何实现了`mockey.TestingT`接口的值：
+
+```go
+type TestingT interface {
+	Cleanup(func())
+}
+```
+
+`*testing.T`、`*testing.B`和`*testing.F`均满足该接口，因此`BuildT`可用于单元测试、基准测试和模糊测试。`BuildT` 也可以与`PatchRun`或`PatchConvey`组合使用：内层作用域的清理先执行，随后外层的`t.Cleanup`作为幂等的无操作执行（`UnPatch`是幂等的）。
 
 ### 提供 `GetMethod` 处理特殊情况
 在无法直接 mock 或者 mock 不生效特殊情况下，可以使用`GetMethod`在获取相应方法后 mock，使用前请确保传入的对象不为 nil。

--- a/mock.go
+++ b/mock.go
@@ -205,6 +205,28 @@ func (builder *MockBuilder) Build() *Mocker {
 	return &mocker
 }
 
+// TestingT is the minimal subset of *testing.T that BuildT depends on.
+// *testing.T, *testing.B, and *testing.F all satisfy this interface.
+type TestingT interface {
+	Cleanup(func())
+}
+
+// BuildT builds the mock (same as Build) and registers t.Cleanup to UnPatch
+// it when the test or subtest exits.
+//
+// Equivalent to:
+//
+//	m := builder.Build()
+//	t.Cleanup(func() { m.UnPatch() })
+//
+// Panics if t is nil.
+func (builder *MockBuilder) BuildT(t TestingT) *Mocker {
+	tool.Assert(t != nil, "BuildT called with nil t")
+	m := builder.Build()
+	t.Cleanup(func() { m.UnPatch() })
+	return m
+}
+
 func (mocker *Mocker) build() {
 	mocker.target = reflect.ValueOf(mocker.builder.target)
 

--- a/mock_test.go
+++ b/mock_test.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"strings"
 	"testing"
 	"time"
 
@@ -444,5 +445,168 @@ func TestMultiArgs(t *testing.T) {
 				So(_x, ShouldEqual, 0)
 			}
 		})
+	})
+}
+
+// Compile-time assertions that the standard *testing types satisfy TestingT.
+// If Go ever removed Cleanup from any of them (it won't), this catches it.
+var (
+	_ TestingT = (*testing.T)(nil)
+	_ TestingT = (*testing.B)(nil)
+	_ TestingT = (*testing.F)(nil)
+)
+
+//go:noinline
+func buildTFoo() string {
+	return "original"
+}
+
+func TestBuildT_BasicCleanup(t *testing.T) {
+	t.Run("inner", func(t *testing.T) {
+		Mock(buildTFoo).Return("mocked").BuildT(t)
+		if got := buildTFoo(); got != "mocked" {
+			t.Fatalf("inside inner: got %q, want %q", got, "mocked")
+		}
+	})
+	if got := buildTFoo(); got != "original" {
+		t.Fatalf("after inner returned: got %q, want %q (cleanup did not fire)", got, "original")
+	}
+}
+
+//go:noinline
+func buildTBar() string {
+	return "original-bar"
+}
+
+func TestBuildT_NilPanics(t *testing.T) {
+	defer func() {
+		r := recover()
+		if r == nil {
+			t.Fatal("expected panic on BuildT(nil)")
+		}
+		msg, _ := r.(string)
+		if !strings.Contains(msg, "BuildT called with nil t") {
+			t.Fatalf("unexpected panic message: %v", r)
+		}
+		// The assertion must fire before Build(), so the target
+		// must remain unpatched.
+		if got := buildTBar(); got != "original-bar" {
+			t.Fatalf("buildTBar was patched (and leaked): got %q", got)
+		}
+	}()
+	Mock(buildTBar).Return("mocked").BuildT(nil)
+}
+
+//go:noinline
+func buildTBaz() string {
+	return "original-baz"
+}
+
+//go:noinline
+func buildTChild() string {
+	return "original-child"
+}
+
+func TestBuildT_Subtests(t *testing.T) {
+	t.Run("parent", func(t *testing.T) {
+		Mock(buildTBaz).Return("outer").BuildT(t)
+		if got := buildTBaz(); got != "outer" {
+			t.Fatalf("parent: got %q, want %q", got, "outer")
+		}
+
+		t.Run("child", func(t *testing.T) {
+			// Mock a different target in the child. mockey panics on
+			// re-mocking the same target without Release first
+			// (see global.go:37 "re-mock %v, previous mock at: %v"),
+			// so the cleanest way to verify per-subtest scoping is to
+			// have parent and child mock different functions.
+			Mock(buildTChild).Return("child-mocked").BuildT(t)
+			if got := buildTChild(); got != "child-mocked" {
+				t.Fatalf("child: buildTChild got %q, want %q", got, "child-mocked")
+			}
+			if got := buildTBaz(); got != "outer" {
+				t.Fatalf("child: buildTBaz parent mock not visible: got %q, want %q", got, "outer")
+			}
+		})
+
+		// Child's mock on buildTChild is cleaned up; parent's mock on
+		// buildTBaz is still active.
+		if got := buildTChild(); got != "original-child" {
+			t.Fatalf("after child: buildTChild not restored: got %q, want %q", got, "original-child")
+		}
+		if got := buildTBaz(); got != "outer" {
+			t.Fatalf("after child: parent mock cleared: got %q, want %q", got, "outer")
+		}
+	})
+
+	if got := buildTBaz(); got != "original-baz" {
+		t.Fatalf("after parent: buildTBaz not restored: got %q, want %q", got, "original-baz")
+	}
+}
+
+//go:noinline
+func buildTQux() string {
+	return "original-qux"
+}
+
+func TestBuildT_WithPatchRun(t *testing.T) {
+	PatchRun(func() {
+		Mock(buildTQux).Return("mocked").BuildT(t)
+		if got := buildTQux(); got != "mocked" {
+			t.Fatalf("inside PatchRun: got %q, want %q", got, "mocked")
+		}
+	})
+	// PatchRun's closure-scoped cleanup runs first; t.Cleanup runs at the
+	// end of TestBuildT_WithPatchRun and must not panic on the
+	// already-unpatched mocker.
+	if got := buildTQux(); got != "original-qux" {
+		t.Fatalf("after PatchRun: got %q, want %q", got, "original-qux")
+	}
+}
+
+//go:noinline
+func buildTManual() string {
+	return "original-manual"
+}
+
+func TestBuildT_ManualUnPatchFirst(t *testing.T) {
+	t.Run("inner", func(t *testing.T) {
+		m := Mock(buildTManual).Return("mocked").BuildT(t)
+		if got := buildTManual(); got != "mocked" {
+			t.Fatalf("before manual UnPatch: got %q, want %q", got, "mocked")
+		}
+		m.UnPatch()
+		if got := buildTManual(); got != "original-manual" {
+			t.Fatalf("after manual UnPatch: got %q, want %q", got, "original-manual")
+		}
+		// When the inner subtest exits, t.Cleanup will fire and call
+		// UnPatch again on the already-unpatched mocker. This must be a
+		// no-op (no panic).
+	})
+	if got := buildTManual(); got != "original-manual" {
+		t.Fatalf("after inner: got %q, want %q", got, "original-manual")
+	}
+}
+
+//go:noinline
+func buildTCount() int {
+	return 0
+}
+
+func TestBuildT_ReturnsMocker(t *testing.T) {
+	t.Run("inner", func(t *testing.T) {
+		m := Mock(buildTCount).Return(42).BuildT(t)
+		if m == nil {
+			t.Fatal("BuildT returned nil")
+		}
+		_ = buildTCount()
+		_ = buildTCount()
+		_ = buildTCount()
+		if got := m.Times(); got != 3 {
+			t.Fatalf("Times: got %d, want 3", got)
+		}
+		if got := m.MockTimes(); got != 3 {
+			t.Fatalf("MockTimes: got %d, want 3", got)
+		}
 	})
 }


### PR DESCRIPTION
#### What type of PR is this?

feat: A new feature

#### What this PR does / why we need it (en: English/zh: Chinese):

Adds `MockBuilder.BuildT(t TestingT) *Mocker`, which builds the mock and registers `t.Cleanup` so the mock is automatically released when the test or subtest exits.

`BuildT` makes writing a idiomatic Go subtest (via t.Run) cleaner:

Before:

```go
func TestX(t *testing.T) {
  t.Run("subtest", func(*testing.T) {
    mockey.PatchRun(func() {
      mockey.Mock(...).Build() // need to be indented twice
    })
  })
}
```

After:

```go
func TestX(t *testing.T) {
  t.Run("subtest", func(*testing.T) {
    mockey.Mock(...).BuildT(t) // only need to be indented once
  })
}
```
  
en: add BuildT() method to clean up mock when the test ends.
zh: 添加 BuildT() 方法，在测试结束时清理 mock.

#### Which issue(s) this PR fixes:

N/A