### PR TITLE
feat: support RISC-V64 Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ func TestWin(t *testing.T) {
 - ARM64
 
 ### Version Support 
-- Go 1.13+
+- Go 1.24+
 
 ## Basic Features
 ### Simple function/method

--- a/README.md
+++ b/README.md
@@ -95,9 +95,11 @@ func TestWin(t *testing.T) {
 ### Arch Support 
 - AMD64
 - ARM64
+- RISC-V64 (Linux)
 
 ### Version Support 
 - Go 1.24+
+- Linux/RISC-V64 requires Go 1.26+
 
 ## Basic Features
 ### Simple function/method

--- a/README_cn.md
+++ b/README_cn.md
@@ -97,9 +97,11 @@ func TestWin(t *testing.T) {
 ### 架构支持
 - AMD64
 - ARM64
+- RISC-V64（Linux）
 
 ### 版本支持
 - Go 1.24+
+- Linux/RISC-V64 需要 Go 1.26+
 
 ## 基础特性
 ### 简单函数/方法

--- a/README_cn.md
+++ b/README_cn.md
@@ -99,7 +99,7 @@ func TestWin(t *testing.T) {
 - ARM64
 
 ### 版本支持
-- Go 1.13+
+- Go 1.24+
 
 ## 基础特性
 ### 简单函数/方法

--- a/global.go
+++ b/global.go
@@ -18,40 +18,250 @@ package mockey
 
 import (
 	"reflect"
+	"sync"
 
 	"github.com/bytedance/mockey/internal/tool"
 	"github.com/smartystreets/goconvey/convey"
 )
 
-var gMocker = make([]map[uintptr]mockerInstance, 0)
+type mockScope struct {
+	owner      int64
+	byIdentity map[uintptr]mockerInstance
+	order      []mockerInstance
+}
 
-func init() {
-	gMocker = append(gMocker, make(map[uintptr]mockerInstance))
+var (
+	// mockLifecycleMu serializes all process-wide target and layer changes.
+	mockLifecycleMu sync.Mutex
+	// mockRegistryMu protects scope and registration metadata only.
+	mockRegistryMu        sync.Mutex
+	rootMockScope         = &mockScope{byIdentity: make(map[uintptr]mockerInstance)}
+	mockScopesByGoroutine = make(map[int64][]*mockScope)
+	mockScopeByInstance   = make(map[mockerInstance]*mockScope)
+	mockOwnerByInstance   = make(map[mockerInstance]int64)
+	mockLayersByPatchKey  = make(map[uintptr][]mockerInstance)
+)
+
+func registrationOwner(scope *mockScope, goroutineID int64) int64 {
+	if scope == rootMockScope {
+		return goroutineID
+	}
+	return scope.owner
+}
+
+// registrationScopeLocked selects a local scope first, then the innermost scope
+// of the sole active owner. It falls back to root when ownership is ambiguous.
+func registrationScopeLocked(goroutineID int64) *mockScope {
+	if scopes := mockScopesByGoroutine[goroutineID]; len(scopes) > 0 {
+		return scopes[len(scopes)-1]
+	}
+
+	var soleScopes []*mockScope
+	for _, scopes := range mockScopesByGoroutine {
+		if len(scopes) == 0 {
+			continue
+		}
+		if soleScopes != nil {
+			return rootMockScope
+		}
+		soleScopes = scopes
+	}
+	if len(soleScopes) > 0 {
+		return soleScopes[len(soleScopes)-1]
+	}
+	return rootMockScope
+}
+
+// localMockScopeLocked never inherits a context owned by another goroutine.
+func localMockScopeLocked(goroutineID int64) *mockScope {
+	if scopes := mockScopesByGoroutine[goroutineID]; len(scopes) > 0 {
+		return scopes[len(scopes)-1]
+	}
+	return rootMockScope
 }
 
 func addToGlobal(mocker mockerInstance) {
-	key := mocker.key()
-	tool.DebugPrintf("[addToGlobal] 0x%x added\n", key)
-	last, ok := gMocker[len(gMocker)-1][key]
-	if ok {
-		tool.Assert(!ok, "re-mock %v, previous mock at: %v", last.name(), last.caller())
+	goroutineID := tool.GetGoroutineID()
+	mockRegistryMu.Lock()
+	defer mockRegistryMu.Unlock()
+
+	scope := registrationScopeLocked(goroutineID)
+	// Keep registration defensive even though callers validate before mutating a target.
+	assertNotInGlobalLocked(mocker, scope, goroutineID)
+	identityKey := mocker.identityKey()
+	patchKey := mocker.layerKey()
+	tool.DebugPrintf("[addToGlobal] identity 0x%x, patch target 0x%x added\n", identityKey, patchKey)
+	scope.byIdentity[identityKey] = mocker
+	scope.order = append(scope.order, mocker)
+	mockScopeByInstance[mocker] = scope
+	mockOwnerByInstance[mocker] = registrationOwner(scope, goroutineID)
+	mockLayersByPatchKey[patchKey] = append(mockLayersByPatchKey[patchKey], mocker)
+}
+
+func assertNotInGlobal(mocker mockerInstance) {
+	goroutineID := tool.GetGoroutineID()
+	mockRegistryMu.Lock()
+	defer mockRegistryMu.Unlock()
+	assertNotInGlobalLocked(mocker, registrationScopeLocked(goroutineID), goroutineID)
+}
+
+func assertNotInGlobalLocked(mocker mockerInstance, scope *mockScope, goroutineID int64) {
+	identityKey := mocker.identityKey()
+	if last, ok := scope.byIdentity[identityKey]; ok {
+		tool.Assert(false, "re-mock %v, previous mock at: %v", last.name(), last.caller())
 	}
-	gMocker[len(gMocker)-1][key] = mocker
+
+	patchKey := mocker.layerKey()
+	layers := mockLayersByPatchKey[patchKey]
+	if len(layers) == 0 {
+		return
+	}
+	previous := layers[len(layers)-1]
+	previousScope, registered := mockScopeByInstance[previous]
+	tool.Assert(registered, "patch target 0x%x has inconsistent layer metadata", patchKey)
+	previousOwner, ownerRegistered := mockOwnerByInstance[previous]
+	tool.Assert(ownerRegistered, "patch target 0x%x has inconsistent owner metadata", patchKey)
+	if previousScope == rootMockScope && scope != rootMockScope {
+		return
+	}
+	if previousScope == rootMockScope && scope == rootMockScope && previousOwner == goroutineID {
+		return
+	}
+	if previousScope != rootMockScope && scope != rootMockScope && previousScope.owner == scope.owner {
+		return
+	}
+	tool.Assert(false, "cannot layer mock %v across concurrent mock scope owners, previous mock at: %v", mocker.name(), previous.caller())
+}
+
+func assertTopInGlobal(mocker mockerInstance) {
+	mockRegistryMu.Lock()
+	defer mockRegistryMu.Unlock()
+
+	patchKey := mocker.layerKey()
+	layers := mockLayersByPatchKey[patchKey]
+	tool.Assert(len(layers) > 0 && layers[len(layers)-1] == mocker, "mocks for patch target 0x%x must be unpatched in reverse creation order", patchKey)
 }
 
 func removeFromGlobal(mocker mockerInstance) {
-	key := mocker.key()
-	tool.DebugPrintf("[removeFromGlobal] 0x%x removed\n", key)
-	delete(gMocker[len(gMocker)-1], key)
+	mockRegistryMu.Lock()
+	defer mockRegistryMu.Unlock()
+
+	identityKey := mocker.identityKey()
+	patchKey := mocker.layerKey()
+	scope, registered := mockScopeByInstance[mocker]
+	tool.Assert(registered, "mocker identity 0x%x is not registered", identityKey)
+	current, ok := scope.byIdentity[identityKey]
+	tool.Assert(ok && current == mocker, "mocker identity 0x%x has inconsistent scope metadata", identityKey)
+	layers := mockLayersByPatchKey[patchKey]
+	tool.Assert(len(layers) > 0 && layers[len(layers)-1] == mocker, "mocks for patch target 0x%x must be unpatched in reverse creation order", patchKey)
+	orderIndex := -1
+	for index := len(scope.order) - 1; index >= 0; index-- {
+		if scope.order[index] == mocker {
+			orderIndex = index
+			break
+		}
+	}
+	tool.Assert(orderIndex >= 0, "mocker identity 0x%x has inconsistent order metadata", identityKey)
+
+	tool.DebugPrintf("[removeFromGlobal] identity 0x%x, patch target 0x%x removed\n", identityKey, patchKey)
+	delete(scope.byIdentity, identityKey)
+	scope.order = append(scope.order[:orderIndex], scope.order[orderIndex+1:]...)
+	delete(mockScopeByInstance, mocker)
+	delete(mockOwnerByInstance, mocker)
+	if len(layers) == 1 {
+		delete(mockLayersByPatchKey, patchKey)
+	} else {
+		mockLayersByPatchKey[patchKey] = layers[:len(layers)-1]
+	}
+}
+
+func pushGlobalScope() *mockScope {
+	goroutineID := tool.GetGoroutineID()
+	mockLifecycleMu.Lock()
+	defer mockLifecycleMu.Unlock()
+
+	mockRegistryMu.Lock()
+	defer mockRegistryMu.Unlock()
+	scope := &mockScope{owner: goroutineID, byIdentity: make(map[uintptr]mockerInstance)}
+	mockScopesByGoroutine[goroutineID] = append(mockScopesByGoroutine[goroutineID], scope)
+	return scope
+}
+
+func popGlobalScope(scope *mockScope) {
+	goroutineID := tool.GetGoroutineID()
+	mockLifecycleMu.Lock()
+	defer mockLifecycleMu.Unlock()
+
+	mockRegistryMu.Lock()
+	scopes := mockScopesByGoroutine[goroutineID]
+	ownsScope := scope != nil && scope.owner == goroutineID && len(scopes) > 0 && scopes[len(scopes)-1] == scope
+	mockRegistryMu.Unlock()
+	tool.Assert(ownsScope, "mock scope must be popped by its owning goroutine in reverse nesting order")
+
+	unpatchAllScopeLocked(scope)
+	mockRegistryMu.Lock()
+	defer mockRegistryMu.Unlock()
+	scopes = mockScopesByGoroutine[goroutineID]
+	tool.Assert(len(scopes) > 0 && scopes[len(scopes)-1] == scope, "mock scope ownership changed during cleanup")
+	if len(scopes) == 1 {
+		delete(mockScopesByGoroutine, goroutineID)
+	} else {
+		mockScopesByGoroutine[goroutineID] = scopes[:len(scopes)-1]
+	}
+}
+
+func unpatchAllScopeLocked(scope *mockScope) {
+	for {
+		mockRegistryMu.Lock()
+		if len(scope.order) == 0 {
+			mockRegistryMu.Unlock()
+			return
+		}
+		mocker := scope.order[len(scope.order)-1]
+		mockRegistryMu.Unlock()
+
+		mocker.unPatchLocked()
+	}
+}
+
+func unpatchAllRootScopeLocked() {
+	for {
+		mocker := nextRootCleanupCandidate()
+		if mocker == nil {
+			return
+		}
+		mocker.unPatchLocked()
+	}
+}
+
+func nextRootCleanupCandidate() mockerInstance {
+	mockRegistryMu.Lock()
+	defer mockRegistryMu.Unlock()
+
+	for index := len(rootMockScope.order) - 1; index >= 0; index-- {
+		mocker := rootMockScope.order[index]
+		layers := mockLayersByPatchKey[mocker.layerKey()]
+		tool.Assert(len(layers) > 0, "root mock for patch target 0x%x has inconsistent layer metadata", mocker.layerKey())
+		if layers[len(layers)-1] == mocker {
+			return mocker
+		}
+	}
+	return nil
 }
 
 // PatchConvey creates a test context that automatically manages mock lifecycles.
 // It wraps around the `convey.Convey` function and adds automatic mock cleanup functionality.
+// Context scopes are owned by the goroutine that entered them, so overlapping
+// contexts in different goroutines clean up independently. A goroutine without a
+// local context joins the innermost context of the sole active owner. With multiple
+// active owners, its mocks belong to the shared root scope because ownership is ambiguous.
+// Concurrent owners cannot layer mocks on the same target; the second mock is
+// rejected before the target is rewritten.
 //
 // Benefits:
 // - No need to manually manage mock cleanup with defer statements
 // - Supports nested contexts, where each level only cleans up its own mocks
-// - Ensures proper mock isolation between test cases
+// - Ensures cleanup between properly nested test cases
 //
 // Usage examples:
 //
@@ -79,13 +289,8 @@ func PatchConvey(items ...interface{}) {
 	for i, item := range items {
 		if reflect.TypeOf(item).Kind() == reflect.Func {
 			items[i] = reflect.MakeFunc(reflect.TypeOf(item), func(args []reflect.Value) []reflect.Value {
-				gMocker = append(gMocker, make(map[uintptr]mockerInstance))
-				defer func() {
-					for _, mocker := range gMocker[len(gMocker)-1] {
-						mocker.unPatch()
-					}
-					gMocker = gMocker[:len(gMocker)-1]
-				}()
+				scope := pushGlobalScope()
+				defer popGlobalScope(scope)
 				return tool.ReflectCall(reflect.ValueOf(item), args)
 			}).Interface()
 		}
@@ -100,6 +305,13 @@ func PatchConvey(items ...interface{}) {
 // - No need to manually manage mock cleanup with defer statements
 // - Supports nested contexts, where each level only cleans up its own mocks
 // - More lightweight than PatchConvey when goconvey integration is not needed
+//
+// Context scopes are owned by the goroutine that entered them, so overlapping
+// contexts in different goroutines clean up independently. A goroutine without a
+// local context joins the innermost context of the sole active owner. With multiple
+// active owners, its mocks belong to the shared root scope because ownership is ambiguous.
+// Concurrent owners cannot layer mocks on the same target; the second mock is
+// rejected before the target is rewritten.
 //
 // Usage example:
 //
@@ -133,18 +345,17 @@ func PatchConvey(items ...interface{}) {
 //	// All mocks are cleaned up
 //	resultA := functionA() // Returns original value
 func PatchRun(f func()) {
-	gMocker = append(gMocker, make(map[uintptr]mockerInstance))
-	defer func() {
-		for _, mocker := range gMocker[len(gMocker)-1] {
-			mocker.unPatch()
-		}
-		gMocker = gMocker[:len(gMocker)-1]
-	}()
+	scope := pushGlobalScope()
+	defer popGlobalScope(scope)
 	f()
 }
 
-// UnPatchAll unpatch all mocks in current `PatchConvey` or `PatchRun` context. If the caller is out of `PatchConvey`
-// or `PatchRun`, it will unpatch all mocks.
+// UnPatchAll unpatches all mocks in the caller's current `PatchConvey` or `PatchRun` context.
+// A caller without a local context unpatches the shared root scope, even while contexts
+// owned by other goroutines are active.
+// Root mocks shadowed by active child layers are skipped while other safe root mocks
+// are cleaned. After the child layer exits, call UnPatchAll again to clean the restored
+// root layer. Cleanup of a local context remains strictly LIFO.
 //
 // For example:
 //
@@ -166,7 +377,15 @@ func PatchRun(f func()) {
 //		}
 //	}
 func UnPatchAll() {
-	for _, mocker := range gMocker[len(gMocker)-1] {
-		mocker.unPatch()
+	goroutineID := tool.GetGoroutineID()
+	mockLifecycleMu.Lock()
+	defer mockLifecycleMu.Unlock()
+	mockRegistryMu.Lock()
+	scope := localMockScopeLocked(goroutineID)
+	mockRegistryMu.Unlock()
+	if scope == rootMockScope {
+		unpatchAllRootScopeLocked()
+		return
 	}
+	unpatchAllScopeLocked(scope)
 }

--- a/global_test.go
+++ b/global_test.go
@@ -18,8 +18,10 @@ package mockey
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
+	"github.com/bytedance/mockey/internal/tool"
 	"github.com/smartystreets/goconvey/convey"
 )
 
@@ -260,5 +262,597 @@ func TestUnpatchAll_PatchRun(t *testing.T) {
 	r1, r2, r3 = fn1(), fn2(), fn3()
 	if r1 != "fn1" || r2 != "fn2" || r3 != "fn3" {
 		t.Errorf("mock state incorrect after final UnPatchAll: fn1=%q, fn2=%q, fn3=%q", r1, r2, r3)
+	}
+}
+
+type lifecycleOrderMocker struct {
+	id    int
+	order *[]int
+}
+
+func (mocker *lifecycleOrderMocker) identityKey() uintptr {
+	return uintptr(mocker.id)
+}
+
+func (mocker *lifecycleOrderMocker) layerKey() uintptr {
+	return mocker.identityKey()
+}
+
+func (mocker *lifecycleOrderMocker) name() string {
+	return fmt.Sprintf("lifecycle mocker %d", mocker.id)
+}
+
+func (mocker *lifecycleOrderMocker) unPatchLocked() {
+	*mocker.order = append(*mocker.order, mocker.id)
+	removeFromGlobal(mocker)
+}
+
+func (mocker *lifecycleOrderMocker) caller() tool.CallerInfo {
+	return tool.CallerInfo{}
+}
+
+func TestPatchRunCleanupUsesLIFOOrder(t *testing.T) {
+	var order []int
+	PatchRun(func() {
+		mockLifecycleMu.Lock()
+		defer mockLifecycleMu.Unlock()
+
+		addToGlobal(&lifecycleOrderMocker{id: 1, order: &order})
+		addToGlobal(&lifecycleOrderMocker{id: 2, order: &order})
+		addToGlobal(&lifecycleOrderMocker{id: 3, order: &order})
+	})
+
+	if got := fmt.Sprint(order); got != "[3 2 1]" {
+		t.Fatalf("cleanup order = %s, want [3 2 1]", got)
+	}
+}
+
+//go:noinline
+func concurrentBuildTarget() int {
+	return 0
+}
+
+func TestConcurrentBuildHasSingleWinner(t *testing.T) {
+	const workers = 8
+	builders := make([]*MockBuilder, workers)
+	for i := range builders {
+		builders[i] = Mock(concurrentBuildTarget).Return(i + 1)
+	}
+
+	PatchRun(func() {
+		start := make(chan struct{})
+		results := make(chan int, workers)
+		for i, builder := range builders {
+			go func(value int, builder *MockBuilder) {
+				<-start
+				defer func() {
+					if recover() != nil {
+						results <- 0
+					}
+				}()
+				builder.Build()
+				results <- value
+			}(i+1, builder)
+		}
+
+		close(start)
+		winner := 0
+		successCount := 0
+		for range workers {
+			if value := <-results; value != 0 {
+				successCount++
+				winner = value
+			}
+		}
+		if successCount != 1 {
+			t.Fatalf("successful builds = %d, want 1", successCount)
+		}
+		if got := concurrentBuildTarget(); got != winner {
+			t.Fatalf("patched target = %d, want winner %d", got, winner)
+		}
+		UnPatchAll()
+		if got := concurrentBuildTarget(); got != 0 {
+			t.Fatalf("target after cleanup = %d, want 0", got)
+		}
+	})
+}
+
+func TestConcurrentRootBuildHasSingleWinner(t *testing.T) {
+	UnPatchAll()
+	defer UnPatchAll()
+
+	const workers = 8
+	builders := make([]*MockBuilder, workers)
+	for i := range builders {
+		builders[i] = Mock(concurrentBuildTarget).Return(i + 1)
+	}
+
+	start := make(chan struct{})
+	results := make(chan int, workers)
+	for i, builder := range builders {
+		go func(value int, builder *MockBuilder) {
+			<-start
+			defer func() {
+				if recover() != nil {
+					results <- 0
+				}
+			}()
+			builder.Build()
+			results <- value
+		}(i+1, builder)
+	}
+
+	close(start)
+	winner := 0
+	successCount := 0
+	for range workers {
+		if value := <-results; value != 0 {
+			successCount++
+			winner = value
+		}
+	}
+	if successCount != 1 {
+		t.Fatalf("successful root-scope builds = %d, want 1", successCount)
+	}
+	if got := concurrentBuildTarget(); got != winner {
+		t.Fatalf("patched root-scope target = %d, want winner %d", got, winner)
+	}
+	UnPatchAll()
+	if got := concurrentBuildTarget(); got != 0 {
+		t.Fatalf("root-scope target after cleanup = %d, want 0", got)
+	}
+}
+
+//go:noinline
+func layeredProxyTarget(value int) int {
+	return value + 1
+}
+
+func TestLayeredFunctionProxyChain(t *testing.T) {
+	var firstOrigin func(int) int
+
+	PatchRun(func() {
+		first := Mock(layeredProxyTarget).
+			To(func(value int) int {
+				return firstOrigin(value) + 10
+			}).
+			Origin(&firstOrigin).
+			Build()
+		if got := layeredProxyTarget(1); got != 12 {
+			t.Fatalf("first layer result = %d, want 12", got)
+		}
+
+		PatchRun(func() {
+			var secondOrigin func(int) int
+			second := Mock(layeredProxyTarget).
+				To(func(value int) int {
+					return secondOrigin(value) * 2
+				}).
+				Origin(&secondOrigin).
+				Build()
+			if got := layeredProxyTarget(1); got != 24 {
+				t.Fatalf("second layer result = %d, want 24", got)
+			}
+			second.UnPatch()
+			if got := layeredProxyTarget(1); got != 12 {
+				t.Fatalf("result after second unpatch = %d, want 12", got)
+			}
+		})
+		if got := layeredProxyTarget(1); got != 12 {
+			t.Fatalf("result after inner cleanup = %d, want 12", got)
+		}
+		first.UnPatch()
+		if got := layeredProxyTarget(1); got != 2 {
+			t.Fatalf("result after first unpatch = %d, want 2", got)
+		}
+	})
+	if got := layeredProxyTarget(1); got != 2 {
+		t.Fatalf("result after PatchRun = %d, want 2", got)
+	}
+}
+
+func runBlockedPatchScope(target *int, mocked int, entered chan<- struct{}, release <-chan struct{}, done chan<- interface{}) {
+	var recovered interface{}
+	func() {
+		defer func() { recovered = recover() }()
+		PatchRun(func() {
+			MockValue(target).To(mocked)
+			close(entered)
+			<-release
+		})
+	}()
+	done <- recovered
+}
+
+func TestInterleavedPatchRunScopesKeepOwnership(t *testing.T) {
+	UnPatchAll()
+	defer UnPatchAll()
+
+	first := 1
+	second := 2
+	root := 3
+
+	firstEntered := make(chan struct{})
+	releaseFirst := make(chan struct{})
+	firstDone := make(chan interface{}, 1)
+	go runBlockedPatchScope(&first, 10, firstEntered, releaseFirst, firstDone)
+	<-firstEntered
+
+	secondEntered := make(chan struct{})
+	releaseSecond := make(chan struct{})
+	secondDone := make(chan interface{}, 1)
+	go runBlockedPatchScope(&second, 20, secondEntered, releaseSecond, secondDone)
+	<-secondEntered
+
+	MockValue(&root).To(30)
+
+	close(releaseFirst)
+	firstPanic := <-firstDone
+	firstAfterExit := first
+	secondDuringFirstExit := second
+	rootDuringScopeCleanup := root
+	close(releaseSecond)
+	secondPanic := <-secondDone
+	secondAfterExit := second
+
+	if firstPanic != nil {
+		t.Fatalf("first scope cleanup panicked: %v", firstPanic)
+	}
+	if secondPanic != nil {
+		t.Fatalf("second scope cleanup panicked: %v", secondPanic)
+	}
+	if firstAfterExit != 1 {
+		t.Fatalf("first value after its scope exit = %d, want 1", firstAfterExit)
+	}
+	if secondDuringFirstExit != 20 {
+		t.Fatalf("second value during first scope exit = %d, want 20", secondDuringFirstExit)
+	}
+	if rootDuringScopeCleanup != 30 {
+		t.Fatalf("ambiguous root value during scope cleanup = %d, want 30", rootDuringScopeCleanup)
+	}
+	if secondAfterExit != 2 {
+		t.Fatalf("second value after its scope exit = %d, want 2", secondAfterExit)
+	}
+
+	UnPatchAll()
+	if root != 3 {
+		t.Fatalf("root value after root cleanup = %d, want 3", root)
+	}
+}
+
+func TestNestedScopeChildJoinsInnermostOwnerScope(t *testing.T) {
+	UnPatchAll()
+	defer UnPatchAll()
+
+	value := 1
+	duringInner := 0
+	afterInner := 0
+	var childPanic interface{}
+
+	PatchRun(func() {
+		PatchRun(func() {
+			done := make(chan interface{}, 1)
+			go func() {
+				defer func() { done <- recover() }()
+				MockValue(&value).To(2)
+			}()
+			childPanic = <-done
+			duringInner = value
+		})
+		afterInner = value
+	})
+
+	if childPanic != nil {
+		t.Fatalf("child mock panicked: %v", childPanic)
+	}
+	if duringInner != 2 {
+		t.Fatalf("value during inner scope = %d, want 2", duringInner)
+	}
+	if afterInner != 1 {
+		t.Fatalf("value after inner scope = %d, want 1", afterInner)
+	}
+	if value != 1 {
+		t.Fatalf("value after outer scope = %d, want 1", value)
+	}
+}
+
+func TestUnPatchAllWithoutLocalScopeOnlyCleansRoot(t *testing.T) {
+	UnPatchAll()
+	defer UnPatchAll()
+
+	value := 1
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	done := make(chan interface{}, 1)
+	go runBlockedPatchScope(&value, 2, entered, release, done)
+	<-entered
+
+	UnPatchAll()
+	afterUnPatchAll := value
+	close(release)
+	scopePanic := <-done
+
+	if scopePanic != nil {
+		t.Fatalf("scope cleanup panicked: %v", scopePanic)
+	}
+	if afterUnPatchAll != 2 {
+		t.Fatalf("foreign scope value after UnPatchAll = %d, want 2", afterUnPatchAll)
+	}
+	if value != 1 {
+		t.Fatalf("value after scope exit = %d, want 1", value)
+	}
+}
+
+func TestRootUnPatchAllSkipsShadowedMocks(t *testing.T) {
+	UnPatchAll()
+	defer UnPatchAll()
+
+	safe := 10
+	shadowed := 1
+	MockValue(&safe).To(20)
+	MockValue(&shadowed).To(2)
+
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	done := make(chan interface{}, 1)
+	go runBlockedPatchScope(&shadowed, 3, entered, release, done)
+	<-entered
+
+	var cleanupPanic interface{}
+	func() {
+		defer func() { cleanupPanic = recover() }()
+		UnPatchAll()
+	}()
+	safeAfterCleanup := safe
+	shadowedDuringChild := shadowed
+
+	close(release)
+	childPanic := <-done
+	shadowedAfterChild := shadowed
+
+	UnPatchAll()
+	shadowedAfterRootCleanup := shadowed
+
+	if cleanupPanic != nil {
+		t.Fatalf("root cleanup panicked on a shadowed mock: %v", cleanupPanic)
+	}
+	if safeAfterCleanup != 10 {
+		t.Fatalf("safe root value after cleanup = %d, want 10", safeAfterCleanup)
+	}
+	if shadowedDuringChild != 3 {
+		t.Fatalf("shadowed value during child layer = %d, want 3", shadowedDuringChild)
+	}
+	if childPanic != nil {
+		t.Fatalf("child scope cleanup panicked: %v", childPanic)
+	}
+	if shadowedAfterChild != 2 {
+		t.Fatalf("shadowed value after child cleanup = %d, want root layer 2", shadowedAfterChild)
+	}
+	if shadowedAfterRootCleanup != 1 {
+		t.Fatalf("shadowed value after later root cleanup = %d, want 1", shadowedAfterRootCleanup)
+	}
+	if safe != 10 {
+		t.Fatalf("safe value after final cleanup = %d, want 10", safe)
+	}
+}
+
+type lifecycleGenericMap[K comparable, V any] struct {
+	values map[K]V
+}
+
+func (m *lifecycleGenericMap[K, V]) Get(key K) V {
+	return m.values[key]
+}
+
+func TestSameOwnerGenericGCShapeLayers(t *testing.T) {
+	intResult := 11
+	stringResult := "mock"
+	firstBuilder := Mock((*lifecycleGenericMap[int32, *int]).Get).Return(&intResult)
+	secondBuilder := Mock((*lifecycleGenericMap[int32, *string]).Get).Return(&stringResult)
+	firstPatchKey := firstBuilder.analyzer.RuntimeTargetValue().Pointer()
+	secondPatchKey := secondBuilder.analyzer.RuntimeTargetValue().Pointer()
+	if firstPatchKey != secondPatchKey {
+		t.Fatalf("generic fixtures do not share a gcshape target: 0x%x != 0x%x", firstPatchKey, secondPatchKey)
+	}
+
+	PatchRun(func() {
+		first := firstBuilder.Build()
+		second := secondBuilder.Build()
+		if got := new(lifecycleGenericMap[int32, *int]).Get(1); got != &intResult {
+			t.Fatalf("first generic layer result = %p, want %p", got, &intResult)
+		}
+		if got := new(lifecycleGenericMap[int32, *string]).Get(1); got != &stringResult {
+			t.Fatalf("second generic layer result = %p, want %p", got, &stringResult)
+		}
+
+		second.UnPatch()
+		if got := new(lifecycleGenericMap[int32, *string]).Get(1); got != nil {
+			t.Fatalf("second generic result after unpatch = %p, want nil", got)
+		}
+		if got := new(lifecycleGenericMap[int32, *int]).Get(1); got != &intResult {
+			t.Fatalf("first generic layer after second unpatch = %p, want %p", got, &intResult)
+		}
+
+		first.UnPatch()
+		if got := new(lifecycleGenericMap[int32, *int]).Get(1); got != nil {
+			t.Fatalf("first generic result after unpatch = %p, want nil", got)
+		}
+	})
+}
+
+func TestSameRootOwnerGenericGCShapeLayers(t *testing.T) {
+	UnPatchAll()
+	defer UnPatchAll()
+
+	intResult := 11
+	stringResult := "mock"
+	firstBuilder := Mock((*lifecycleGenericMap[int32, *int]).Get).Return(&intResult)
+	secondBuilder := Mock((*lifecycleGenericMap[int32, *string]).Get).Return(&stringResult)
+	if firstBuilder.analyzer.RuntimeTargetValue().Pointer() != secondBuilder.analyzer.RuntimeTargetValue().Pointer() {
+		t.Fatal("generic fixtures do not share a gcshape target")
+	}
+
+	first := firstBuilder.Build()
+	second := secondBuilder.Build()
+	if got := new(lifecycleGenericMap[int32, *int]).Get(1); got != &intResult {
+		t.Fatalf("first root generic layer result = %p, want %p", got, &intResult)
+	}
+	if got := new(lifecycleGenericMap[int32, *string]).Get(1); got != &stringResult {
+		t.Fatalf("second root generic layer result = %p, want %p", got, &stringResult)
+	}
+
+	second.UnPatch()
+	if got := new(lifecycleGenericMap[int32, *string]).Get(1); got != nil {
+		t.Fatalf("second root generic result after unpatch = %p, want nil", got)
+	}
+	if got := new(lifecycleGenericMap[int32, *int]).Get(1); got != &intResult {
+		t.Fatalf("first root generic layer after second unpatch = %p, want %p", got, &intResult)
+	}
+
+	first.UnPatch()
+	if got := new(lifecycleGenericMap[int32, *int]).Get(1); got != nil {
+		t.Fatalf("first root generic result after unpatch = %p, want nil", got)
+	}
+}
+
+func TestConcurrentRootOwnersRejectSharedGenericGCShape(t *testing.T) {
+	UnPatchAll()
+	defer UnPatchAll()
+
+	intResult := 11
+	stringResult := "mock"
+	originResult := "origin"
+	secondOrigin := func(*lifecycleGenericMap[int32, *string], int32) *string {
+		return &originResult
+	}
+	firstBuilder := Mock((*lifecycleGenericMap[int32, *int]).Get).Return(&intResult)
+	secondBuilder := Mock((*lifecycleGenericMap[int32, *string]).Get).Return(&stringResult).Origin(&secondOrigin)
+	if firstBuilder.analyzer.RuntimeTargetValue().Pointer() != secondBuilder.analyzer.RuntimeTargetValue().Pointer() {
+		t.Fatal("generic fixtures do not share a gcshape target")
+	}
+
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	firstDone := make(chan interface{}, 1)
+	go func() {
+		var recovered interface{}
+		func() {
+			defer func() { recovered = recover() }()
+			first := firstBuilder.Build()
+			close(entered)
+			<-release
+			first.UnPatch()
+		}()
+		firstDone <- recovered
+	}()
+	<-entered
+
+	rejected := make(chan interface{}, 1)
+	go func() {
+		defer func() { rejected <- recover() }()
+		secondBuilder.Build()
+	}()
+	patchPanic := <-rejected
+	firstDuringOwner := new(lifecycleGenericMap[int32, *int]).Get(1)
+	secondDuringOwner := new(lifecycleGenericMap[int32, *string]).Get(1)
+	originAfterRejected := secondOrigin(nil, 0)
+
+	close(release)
+	firstOwnerPanic := <-firstDone
+	firstAfterCleanup := new(lifecycleGenericMap[int32, *int]).Get(1)
+	secondAfterCleanup := new(lifecycleGenericMap[int32, *string]).Get(1)
+
+	if patchPanic == nil {
+		t.Fatal("cross-owner root same-gcshape generic patch did not panic")
+	}
+	if !strings.Contains(fmt.Sprint(patchPanic), "concurrent mock scope owners") {
+		t.Fatalf("cross-owner root generic panic = %v, want owner rejection", patchPanic)
+	}
+	if firstDuringOwner != &intResult {
+		t.Fatalf("active root generic layer after rejection = %p, want %p", firstDuringOwner, &intResult)
+	}
+	if secondDuringOwner != nil {
+		t.Fatalf("rejected root generic instance was mutated: result = %p, want nil", secondDuringOwner)
+	}
+	if originAfterRejected != &originResult {
+		t.Fatalf("rejected root generic build changed Origin: result = %p, want %p", originAfterRejected, &originResult)
+	}
+	if firstOwnerPanic != nil {
+		t.Fatalf("first root generic owner cleanup panicked: %v", firstOwnerPanic)
+	}
+	if firstAfterCleanup != nil {
+		t.Fatalf("first root generic result after cleanup = %p, want nil", firstAfterCleanup)
+	}
+	if secondAfterCleanup != nil {
+		t.Fatalf("second root generic result after cleanup = %p, want nil", secondAfterCleanup)
+	}
+}
+
+func TestConcurrentOwnersRejectSharedGenericGCShape(t *testing.T) {
+	intResult := 11
+	stringResult := "mock"
+	firstBuilder := Mock((*lifecycleGenericMap[int32, *int]).Get).Return(&intResult)
+	secondBuilder := Mock((*lifecycleGenericMap[int32, *string]).Get).Return(&stringResult)
+	if firstBuilder.analyzer.RuntimeTargetValue().Pointer() != secondBuilder.analyzer.RuntimeTargetValue().Pointer() {
+		t.Fatal("generic fixtures do not share a gcshape target")
+	}
+
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	firstDone := make(chan interface{}, 1)
+	go func() {
+		var recovered interface{}
+		func() {
+			defer func() { recovered = recover() }()
+			PatchRun(func() {
+				firstBuilder.Build()
+				close(entered)
+				<-release
+			})
+		}()
+		firstDone <- recovered
+	}()
+	<-entered
+
+	rejected := make(chan interface{}, 1)
+	go func() {
+		var recovered interface{}
+		func() {
+			defer func() { recovered = recover() }()
+			PatchRun(func() {
+				secondBuilder.Build()
+			})
+		}()
+		rejected <- recovered
+	}()
+	patchPanic := <-rejected
+	firstDuringOwner := new(lifecycleGenericMap[int32, *int]).Get(1)
+	secondDuringOwner := new(lifecycleGenericMap[int32, *string]).Get(1)
+
+	close(release)
+	firstOwnerPanic := <-firstDone
+	firstAfterCleanup := new(lifecycleGenericMap[int32, *int]).Get(1)
+	secondAfterCleanup := new(lifecycleGenericMap[int32, *string]).Get(1)
+
+	if patchPanic == nil {
+		t.Fatal("cross-owner same-gcshape generic patch did not panic")
+	}
+	if !strings.Contains(fmt.Sprint(patchPanic), "concurrent mock scope owners") {
+		t.Fatalf("cross-owner generic panic = %v, want owner rejection", patchPanic)
+	}
+	if firstDuringOwner != &intResult {
+		t.Fatalf("active generic layer after rejection = %p, want %p", firstDuringOwner, &intResult)
+	}
+	if secondDuringOwner != nil {
+		t.Fatalf("rejected generic instance was mutated: result = %p, want nil", secondDuringOwner)
+	}
+	if firstOwnerPanic != nil {
+		t.Fatalf("first generic owner cleanup panicked: %v", firstOwnerPanic)
+	}
+	if firstAfterCleanup != nil {
+		t.Fatalf("first generic result after cleanup = %p, want nil", firstAfterCleanup)
+	}
+	if secondAfterCleanup != nil {
+		t.Fatalf("second generic result after cleanup = %p, want nil", secondAfterCleanup)
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -1,10 +1,10 @@
 module github.com/bytedance/mockey
 
-go 1.18
+go 1.24.0
 
 require (
 	github.com/smartystreets/goconvey v1.7.2
-	golang.org/x/arch v0.11.0
+	golang.org/x/arch v0.23.0
 	golang.org/x/sys v0.26.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -20,8 +20,8 @@ github.com/smartystreets/goconvey v1.7.2 h1:9RBaZCeXEQ3UselpuwUQHltGVXvdwm6cv1hg
 github.com/smartystreets/goconvey v1.7.2/go.mod h1:Vw0tHAZW6lzCRk3xgdin6fKYcG+G3Pg9vgXWeJpQFMM=
 github.com/spf13/cobra v0.0.3/go.mod h1:1l0Ry5zgKvJasoi3XT1TypsSe7PqH0Sj9dhYf7v3XqQ=
 github.com/spf13/pflag v1.0.1/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
-golang.org/x/arch v0.11.0 h1:KXV8WWKCXm6tRpLirl2szsO5j/oOODwZf4hATmGVNs4=
-golang.org/x/arch v0.11.0/go.mod h1:FEVrYAQjsQXMVJ1nsMoVVXPZg6p2JE2mx8psSWTDQys=
+golang.org/x/arch v0.23.0 h1:lKF64A2jF6Zd8L0knGltUnegD62JMFBiCPBmQpToHhg=
+golang.org/x/arch v0.23.0/go.mod h1:dNHoOeKiyja7GTvF9NJS1l3Z2yntpQNzgrjh1cU103A=
 golang.org/x/crypto v0.0.0-20180807104621-f027049dab0a/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/net v0.0.0-20190213061140-3a22650c66bd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
@@ -35,5 +35,3 @@ golang.org/x/tools v0.0.0-20190308142131-b40df0fb21c3/go.mod h1:25r3+/G6/xytQM8i
 golang.org/x/tools v0.0.0-20190328211700-ab21143f2384/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
-rsc.io/pdf v0.1.1 h1:k1MczvYDUvJBe93bYd7wrZLLUEcLZAuF824/I4e5Xr4=
-rsc.io/pdf v0.1.1/go.mod h1:n8OzWcQ6Sp37PL01nO98y4iUCRdTGarVfzxY20ICaU4=

--- a/internal/monkey/common/transform.go
+++ b/internal/monkey/common/transform.go
@@ -22,7 +22,7 @@ import (
 )
 
 func PtrOf(val []byte) uintptr {
-	return (*reflect.SliceHeader)(unsafe.Pointer(&val)).Data
+	return uintptr(unsafe.Pointer(unsafe.SliceData(val)))
 }
 
 func PtrAt(val reflect.Value) uintptr {
@@ -33,10 +33,13 @@ func PtrAt(val reflect.Value) uintptr {
 	return uintptr((*value)(unsafe.Pointer(&val)).ptr)
 }
 
-func BytesOf(addr uintptr, size int) (res []byte) {
-	h := (*reflect.SliceHeader)(unsafe.Pointer(&res))
-	h.Data = addr
-	h.Len = size
-	h.Cap = size
-	return res
+func BytesOf(addr uintptr, size int) []byte {
+	return unsafe.Slice((*byte)(pointerOf(addr)), size)
+}
+
+// pointerOf loads a raw virtual address through a pointer-typed view. Callers
+// use BytesOf only for executable code or mmap-backed memory, whose addresses
+// intentionally do not carry Go pointer provenance.
+func pointerOf(addr uintptr) unsafe.Pointer {
+	return *(*unsafe.Pointer)(unsafe.Pointer(&addr))
 }

--- a/internal/monkey/hide_stack_pointer_riscv64_test.s
+++ b/internal/monkey/hide_stack_pointer_riscv64_test.s
@@ -1,0 +1,25 @@
+//go:build riscv64
+// +build riscv64
+
+/*
+ * Copyright 2022 ByteDance Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "textflag.h"
+
+TEXT ·hideStackPointer(SB),NOSPLIT,$0-16
+	MOV	pointer+0(FP), T0
+	MOV	T0, ret+8(FP)
+	RET

--- a/internal/monkey/inst/disasm_riscv64.go
+++ b/internal/monkey/inst/disasm_riscv64.go
@@ -1,0 +1,400 @@
+/*
+ * Copyright 2022 ByteDance Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package inst
+
+import (
+	"fmt"
+	"reflect"
+
+	"github.com/bytedance/mockey/internal/monkey/common"
+	"github.com/bytedance/mockey/internal/tool"
+	"golang.org/x/arch/riscv64/riscv64asm"
+)
+
+func calcFnAddrRange(name string, fn func()) (uintptr, uintptr) {
+	v := reflect.ValueOf(fn)
+	var start, end uintptr
+	start = v.Pointer()
+	maxScan := 2000
+	code := common.BytesOf(start, maxScan)
+	pos := 0
+	for pos < maxScan {
+		inst, err := riscv64asm.Decode(code[pos:])
+		tool.Assert(err == nil, err)
+
+		if isRet(inst) {
+			end = start + uintptr(pos)
+			return start, end
+		}
+
+		pos += inst.Len
+	}
+	tool.Assert(false, "%v end not found", name)
+	return 0, 0
+}
+
+func Disassemble(code []byte, required int, checkLen bool) int {
+	var scan reachableCodeScan
+	pos, maxEnd := 0, 0
+	for {
+		inst, err := riscv64asm.Decode(code[pos:])
+		tool.Assert(err == nil || !checkLen, err)
+		if err != nil || inst.Len <= 0 {
+			return max(maxEnd, pos)
+		}
+		tool.DebugPrintf("Disassemble: %3d\t0x%x\t%v\n", pos, common.PtrOf(code)+uintptr(pos), inst)
+		maxEnd = max(maxEnd, pos+inst.Len)
+		if target, ok := scan.observe(pos, inst, code[pos:]); ok && target > required {
+			required = target
+		}
+		nextPos, stop := scan.advance(pos, inst, required)
+		if stop {
+			if maxEnd < required {
+				tool.Assert(!isRet(inst) || !checkLen, "function is too short to patch")
+				return required
+			}
+			return maxEnd
+		}
+		pos = nextPos
+		if pos >= required {
+			return max(maxEnd, pos)
+		}
+	}
+}
+
+func conditionalBranchTarget(pos int, inst riscv64asm.Inst) (int, bool) {
+	switch inst.Op {
+	case riscv64asm.BEQ, riscv64asm.BNE, riscv64asm.BLT, riscv64asm.BGE, riscv64asm.BLTU, riscv64asm.BGEU:
+		return pos + int(inst.Args[2].(riscv64asm.Simm).Imm), true
+	default:
+		return 0, false
+	}
+}
+
+type reachableTarget struct {
+	offset        int
+	allowBoundary bool
+}
+
+type reachableCodeScan struct {
+	visited map[int]struct{}
+	pending []reachableTarget
+}
+
+func (scan *reachableCodeScan) observe(pos int, inst riscv64asm.Inst, encoding []byte) (int, bool) {
+	if scan.visited == nil {
+		scan.visited = make(map[int]struct{})
+	}
+	scan.visited[pos] = struct{}{}
+
+	if target, ok := conditionalBranchTarget(pos, inst); ok {
+		scan.enqueue(target, true)
+		return target, target > pos
+	}
+	if inst.Op == riscv64asm.JAL {
+		target := pos + int(jalImmediate(encoding, inst))
+		rd := inst.Args[0].(riscv64asm.Reg)
+		scan.enqueue(target, rd == riscv64asm.X0)
+	}
+	return 0, false
+}
+
+func (scan *reachableCodeScan) advance(pos int, inst riscv64asm.Inst, copiedLimit int) (next int, stop bool) {
+	end := pos + inst.Len
+	if instructionHasFallthrough(inst) && end < copiedLimit && !scan.wasVisited(end) {
+		return end, false
+	}
+	if target, ok := scan.takePending(copiedLimit); ok {
+		return target, false
+	}
+	return end, true
+}
+
+func (scan *reachableCodeScan) enqueue(target int, allowBoundary bool) {
+	if target < 0 || scan.wasVisited(target) {
+		return
+	}
+	for index, pending := range scan.pending {
+		if pending.offset == target {
+			scan.pending[index].allowBoundary = pending.allowBoundary || allowBoundary
+			return
+		}
+	}
+	scan.pending = append(scan.pending, reachableTarget{
+		offset:        target,
+		allowBoundary: allowBoundary,
+	})
+}
+
+func (scan *reachableCodeScan) takePending(copiedLimit int) (int, bool) {
+	index := -1
+	target := int(^uint(0) >> 1)
+	for currentIndex, current := range scan.pending {
+		if current.offset > copiedLimit ||
+			current.offset == copiedLimit && !current.allowBoundary ||
+			scan.wasVisited(current.offset) ||
+			current.offset >= target {
+			continue
+		}
+		index = currentIndex
+		target = current.offset
+	}
+	if index < 0 {
+		return 0, false
+	}
+	scan.pending = append(scan.pending[:index], scan.pending[index+1:]...)
+	return target, true
+}
+
+func (scan *reachableCodeScan) wasVisited(pos int) bool {
+	_, ok := scan.visited[pos]
+	return ok
+}
+
+func instructionHasFallthrough(inst riscv64asm.Inst) bool {
+	if isRet(inst) || isIndirectJump(inst) {
+		return false
+	}
+	return inst.Op != riscv64asm.JAL || inst.Args[0].(riscv64asm.Reg) != riscv64asm.X0
+}
+
+func jalImmediate(encoding []byte, inst riscv64asm.Inst) int32 {
+	if inst.Len == 2 {
+		return decodeCJOffset(encoding)
+	}
+	return int32(inst.Args[1].(riscv64asm.Simm).Imm)
+}
+
+func GetGenericAddr(addr uintptr, maxScan int) (jumpAddr, genericInfoAddr uintptr) {
+	code := common.BytesOf(addr, maxScan)
+	var (
+		allJumpInsts []*genericJmpInst
+		allInfoInsts []*genericInfoInst
+		auipcByReg   = map[riscv64asm.Reg]*posInst{}
+		pos          int
+	)
+loop:
+	for pos < maxScan {
+		remaining := code[pos:]
+		// maxScan is a byte limit and may bisect the final 32-bit instruction.
+		// Stop at that boundary after retaining every complete call already seen.
+		if len(remaining) < 2 || (remaining[0]&3 == 3 && len(remaining) < 4) {
+			break
+		}
+		inst, err := riscv64asm.Decode(remaining)
+		tool.Assert(err == nil, err)
+		tool.DebugPrintf("GetGenericAddr: %3d\t0x%x\t%v\n", pos, addr+uintptr(pos), inst)
+
+		switch {
+		case isRet(inst):
+			break loop
+		case inst.Op == riscv64asm.AUIPC:
+			pi := &posInst{pos: pos, addr: addr + uintptr(pos), inst: inst}
+			if reg, ok := auipcDst(inst); ok {
+				auipcByReg[reg] = pi
+			}
+			allInfoInsts = append(allInfoInsts, newGenericInfoInst(pi))
+		case inst.Op == riscv64asm.ADDI:
+			if len(allInfoInsts) > 0 {
+				allInfoInsts[len(allInfoInsts)-1].putAddInst(pos, addr+uintptr(pos), inst)
+			}
+		case isCall(inst):
+			allJumpInsts = append(allJumpInsts, newGenericJmpInst(addr, pos, inst, auipcByReg))
+		}
+		pos += inst.Len
+	}
+
+	var (
+		jumpInst *genericJmpInst
+		infoInst *genericInfoInst
+	)
+	for _, cur := range allJumpInsts {
+		if cur.isExtraCall {
+			continue
+		}
+		tool.Assert(jumpInst == nil, "invalid jumpInsts: %v", allJumpInsts)
+		jumpInst = cur
+	}
+	tool.Assert(jumpInst != nil, "invalid jumpInsts: %v", allJumpInsts)
+	tool.DebugPrintf("jumpInst found: %v\n", jumpInst)
+
+	for _, cur := range allInfoInsts {
+		if cur.matchJumpInst(jumpInst) {
+			infoInst = cur
+		}
+	}
+	if infoInst == nil {
+		tool.DebugPrintf("infoInst not found!\n")
+		return jumpInst.jumpAddr, 0
+	}
+
+	gi := infoInst.calcGenericInfoAddr()
+	tool.DebugPrintf("infoInst found: %v, genericInfoAddr: 0x%x\n", infoInst, gi)
+	return jumpInst.jumpAddr, gi
+}
+
+type posInst struct {
+	pos  int
+	addr uintptr
+	inst riscv64asm.Inst
+}
+
+func (pi *posInst) String() string {
+	return fmt.Sprintf("{pos: %d, addr: 0x%x, inst: %v}", pi.pos, pi.addr, pi.inst)
+}
+
+func newGenericJmpInst(base uintptr, pos int, inst riscv64asm.Inst, auipcByReg map[riscv64asm.Reg]*posInst) *genericJmpInst {
+	ji := &genericJmpInst{
+		posInst: &posInst{pos: pos, addr: base + uintptr(pos), inst: inst},
+	}
+	return ji.init(auipcByReg)
+}
+
+type genericJmpInst struct {
+	*posInst
+	jumpAddr      uintptr
+	isExtraCall   bool
+	extraCallName string
+}
+
+func (g *genericJmpInst) String() string {
+	return fmt.Sprintf("{posInst: %v, jumpAddr: 0x%x, isExtraCall: %v, extraCallName: %v}", g.posInst, g.jumpAddr, g.isExtraCall, g.extraCallName)
+}
+
+func (g *genericJmpInst) init(auipcByReg map[riscv64asm.Reg]*posInst) *genericJmpInst {
+	g.jumpAddr = g.calcJumpAddr(auipcByReg)
+	// Linker-generated trampolines are common for runtime helpers on RISC-V.
+	// Classify the resolved destination, but keep jumpAddr pointing at the
+	// original call target so the generic business call is returned unchanged.
+	resolvedAddr := resolvePCRelativeJump(g.jumpAddr)
+	g.isExtraCall, g.extraCallName = isGenericProxyCallExtra(resolvedAddr)
+	return g
+}
+
+func resolvePCRelativeJump(target uintptr) uintptr {
+	code := common.BytesOf(target, 8)
+	high, err := riscv64asm.Decode(code)
+	if err != nil || high.Op != riscv64asm.AUIPC {
+		return target
+	}
+	rd := high.Args[0].(riscv64asm.Reg)
+	low, err := riscv64asm.Decode(code[high.Len:])
+	if err != nil || low.Op != riscv64asm.JALR {
+		return target
+	}
+	if low.Args[0].(riscv64asm.Reg) != riscv64asm.X0 {
+		return target
+	}
+	regOffset := low.Args[1].(riscv64asm.RegOffset)
+	if regOffset.OfsReg != rd {
+		return target
+	}
+	return uintptr(int64(target) + auipcImm(high) + int64(regOffset.Ofs.Imm))
+}
+
+func (g *genericJmpInst) calcJumpAddr(auipcByReg map[riscv64asm.Reg]*posInst) uintptr {
+	if g.inst.Op == riscv64asm.JAL {
+		var offset int64
+		if g.inst.Len == 2 {
+			offset = int64(decodeCJOffset(common.BytesOf(g.addr, g.inst.Len)))
+		} else {
+			offset = int64(g.inst.Args[1].(riscv64asm.Simm).Imm)
+		}
+		return uintptr(int64(g.addr) + offset)
+	}
+	regOffset := g.inst.Args[1].(riscv64asm.RegOffset)
+	if auipc, ok := auipcByReg[regOffset.OfsReg]; ok {
+		return uintptr(int64(auipc.addr) + auipcImm(auipc.inst) + int64(regOffset.Ofs.Imm))
+	}
+	tool.Assert(false, "missing AUIPC for jump: %v", g)
+	return 0
+}
+
+func newGenericInfoInst(auipc *posInst) *genericInfoInst {
+	return &genericInfoInst{auipc: auipc}
+}
+
+type genericInfoInst struct {
+	auipc *posInst
+	addi  *posInst
+}
+
+func (g *genericInfoInst) String() string {
+	return fmt.Sprintf("{auipc: %v, addi: %v}", g.auipc, g.addi)
+}
+
+func (g *genericInfoInst) matchJumpInst(jumpInst *genericJmpInst) bool {
+	return g.addi != nil && g.addi.pos < jumpInst.pos
+}
+
+func (g *genericInfoInst) putAddInst(pos int, addr uintptr, inst riscv64asm.Inst) {
+	if g.auipc == nil || g.addi != nil || g.auipc.pos+g.auipc.inst.Len != pos {
+		return
+	}
+	auipcReg, ok := auipcDst(g.auipc.inst)
+	if !ok || inst.Args[0].(riscv64asm.Reg) != auipcReg || inst.Args[1].(riscv64asm.Reg) != auipcReg {
+		return
+	}
+	g.addi = &posInst{pos: pos, addr: addr, inst: inst}
+}
+
+func (g *genericInfoInst) calcGenericInfoAddr() uintptr {
+	return uintptr(int64(g.auipc.addr) + auipcImm(g.auipc.inst) + int64(g.addi.inst.Args[2].(riscv64asm.Simm).Imm))
+}
+
+func isRet(inst riscv64asm.Inst) bool {
+	if inst.Op != riscv64asm.JALR {
+		return false
+	}
+	if inst.Args[0].(riscv64asm.Reg) != riscv64asm.X0 {
+		return false
+	}
+	regOffset := inst.Args[1].(riscv64asm.RegOffset)
+	return regOffset.OfsReg == riscv64asm.X1 && regOffset.Ofs.Imm == 0
+}
+
+func isIndirectJump(inst riscv64asm.Inst) bool {
+	return inst.Op == riscv64asm.JALR && inst.Args[0].(riscv64asm.Reg) == riscv64asm.X0 && !isRet(inst)
+}
+
+// isCall is intentionally X1-only: GetGenericAddr wants the generic wrapper
+// business call and must ignore compiler-inserted X5 morestack calls.
+func isCall(inst riscv64asm.Inst) bool {
+	switch inst.Op {
+	case riscv64asm.JAL:
+		return inst.Args[0].(riscv64asm.Reg) == riscv64asm.X1
+	case riscv64asm.JALR:
+		return inst.Args[0].(riscv64asm.Reg) == riscv64asm.X1
+	default:
+		return false
+	}
+}
+
+func auipcDst(inst riscv64asm.Inst) (riscv64asm.Reg, bool) {
+	if inst.Op != riscv64asm.AUIPC {
+		return 0, false
+	}
+	return inst.Args[0].(riscv64asm.Reg), true
+}
+
+func auipcImm(inst riscv64asm.Inst) int64 {
+	imm := int64(inst.Args[1].(riscv64asm.Uimm).Imm)
+	if imm&(1<<19) != 0 {
+		imm |= ^int64((1 << 20) - 1)
+	}
+	return imm << 12
+}

--- a/internal/monkey/inst/go_version_linux_riscv64.go
+++ b/internal/monkey/inst/go_version_linux_riscv64.go
@@ -1,0 +1,22 @@
+//go:build linux && riscv64 && !go1.26
+// +build linux,riscv64,!go1.26
+
+/*
+ * Copyright 2022 ByteDance Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package inst
+
+var _ = mockey_linux_riscv64_requires_go1_26

--- a/internal/monkey/inst/inst_riscv64.go
+++ b/internal/monkey/inst/inst_riscv64.go
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2022 ByteDance Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package inst
+
+import (
+	"encoding/binary"
+)
+
+const (
+	riscv64Zero = 0
+	riscv64RA   = 1
+	riscv64TMP  = 31 // X31 is reserved for assembler use by the Go RISC-V ABI.
+	riscv64CTXT = 26 // S10, Go closure context register.
+)
+
+func BranchTo(to uintptr) (res []byte) {
+	res = append(res, auipc(riscv64TMP, 0)...)             // AUIPC TMP, 0
+	res = append(res, ld(riscv64TMP, riscv64TMP, 16)...)   // LD TMP, 16(TMP)
+	res = append(res, jalr(riscv64Zero, riscv64TMP, 0)...) // JALR ZERO, 0(TMP)
+	res = append(res, nop()...)
+	res = appendUint64(res, uint64(to))
+	return
+}
+
+func BranchInto(to uintptr) (res []byte) {
+	res = append(res, auipc(riscv64CTXT, 0)...)            // AUIPC CTXT, 0
+	res = append(res, ld(riscv64CTXT, riscv64CTXT, 16)...) // LD CTXT, 16(CTXT)
+	res = append(res, ld(riscv64TMP, riscv64CTXT, 0)...)   // LD TMP, 0(CTXT)
+	res = append(res, jalr(riscv64Zero, riscv64TMP, 0)...) // JALR ZERO, 0(TMP)
+	res = appendUint64(res, uint64(to))
+	return
+}
+
+func auipc(rd int, imm20 int32) []byte {
+	return uint32ToBytes(uint32(imm20)<<12 | uint32(rd)<<7 | 0x17)
+}
+
+func ld(rd, rs1 int, imm12 int32) []byte {
+	return uint32ToBytes((uint32(imm12)&0xfff)<<20 | uint32(rs1)<<15 | 0b011<<12 | uint32(rd)<<7 | 0x03)
+}
+
+func addi(rd, rs1 int, imm12 int32) []byte {
+	return uint32ToBytes((uint32(imm12)&0xfff)<<20 | uint32(rs1)<<15 | uint32(rd)<<7 | 0x13)
+}
+
+func jalr(rd, rs1 int, imm12 int32) []byte {
+	return uint32ToBytes((uint32(imm12)&0xfff)<<20 | uint32(rs1)<<15 | uint32(rd)<<7 | 0x67)
+}
+
+func jal(rd int, imm21 int32) []byte {
+	imm := uint32(imm21)
+	inst := ((imm >> 20) & 0x1 << 31) |
+		((imm >> 1) & 0x3ff << 21) |
+		((imm >> 11) & 0x1 << 20) |
+		((imm >> 12) & 0xff << 12) |
+		uint32(rd)<<7 |
+		0x6f
+	return uint32ToBytes(inst)
+}
+
+func nop() []byte {
+	return uint32ToBytes(0x00000013)
+}
+
+func uint32ToBytes(v uint32) []byte {
+	res := make([]byte, 4)
+	binary.LittleEndian.PutUint32(res, v)
+	return res
+}
+
+func appendUint64(res []byte, v uint64) []byte {
+	var buf [8]byte
+	binary.LittleEndian.PutUint64(buf[:], v)
+	return append(res, buf[:]...)
+}
+
+func add(rd, rs1, rs2 int) []byte {
+	return uint32ToBytes(uint32(rs2)<<20 | uint32(rs1)<<15 | uint32(rd)<<7 | 0x33)
+}
+
+// cJ encodes C.J. The immediate bit order is
+// [11|4|9:8|10|6|7|3:1|5] in instruction bits [12:2].
+func cJ(imm12 int32) []byte {
+	imm := uint32(imm12)
+	inst := uint16(0xa001)
+	inst |= uint16((imm>>11)&0x1) << 12
+	inst |= uint16((imm>>4)&0x1) << 11
+	inst |= uint16((imm>>8)&0x3) << 9
+	inst |= uint16((imm>>10)&0x1) << 8
+	inst |= uint16((imm>>6)&0x1) << 7
+	inst |= uint16((imm>>7)&0x1) << 6
+	inst |= uint16((imm>>1)&0x7) << 3
+	inst |= uint16((imm>>5)&0x1) << 2
+	return uint16ToBytes(inst)
+}
+
+// decodeCJOffset decodes the C.J immediate locally. x/arch v0.23 maps
+// instruction bits [5:3] incorrectly, so relocation must not use its Simm.
+func decodeCJOffset(enc []byte) int32 {
+	instruction := binary.LittleEndian.Uint16(enc)
+	var immediate int32
+	immediate |= int32((instruction>>12)&0x1) << 11
+	immediate |= int32((instruction>>11)&0x1) << 4
+	immediate |= int32((instruction>>9)&0x3) << 8
+	immediate |= int32((instruction>>8)&0x1) << 10
+	immediate |= int32((instruction>>7)&0x1) << 6
+	immediate |= int32((instruction>>6)&0x1) << 7
+	immediate |= int32((instruction>>3)&0x7) << 1
+	immediate |= int32((instruction>>2)&0x1) << 5
+	return immediate << 20 >> 20
+}
+
+func uint16ToBytes(v uint16) []byte {
+	res := make([]byte, 2)
+	binary.LittleEndian.PutUint16(res, v)
+	return res
+}

--- a/internal/monkey/inst/inst_riscv64_test.go
+++ b/internal/monkey/inst/inst_riscv64_test.go
@@ -1,0 +1,334 @@
+/*
+ * Copyright 2022 ByteDance Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package inst
+
+import (
+	"bytes"
+	"encoding/binary"
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/bytedance/mockey/internal/monkey/common"
+	"github.com/smartystreets/goconvey/convey"
+	"golang.org/x/arch/riscv64/riscv64asm"
+)
+
+func genericAddrTarget[T int | float64](l, r T) T {
+	return l + r
+}
+
+func TestBranchTo(t *testing.T) {
+	convey.Convey("TestBranchTo", t, func() {
+		inst := fmt.Sprintf("%x", BranchTo(0x123456789abcef01))
+		convey.So(inst, convey.ShouldEqual, "970f000083bf0f0167800f001300000001efbc9a78563412")
+	})
+}
+
+func TestBranchInto(t *testing.T) {
+	convey.Convey("TestBranchInto", t, func() {
+		inst := fmt.Sprintf("%x", BranchInto(0x123456789abcef01))
+		convey.So(inst, convey.ShouldEqual, "170d0000033d0d01833f0d0067800f0001efbc9a78563412")
+	})
+}
+
+func TestDisassembleBranchInto(t *testing.T) {
+	convey.Convey("TestDisassembleBranchInto", t, func() {
+		code := BranchInto(^uintptr(0))
+		convey.So(Disassemble(code, len(code), true), convey.ShouldEqual, len(code))
+	})
+}
+
+func TestGetGenericAddr(t *testing.T) {
+	convey.Convey("TestGetGenericAddr", t, func() {
+		addr := reflect.ValueOf(genericAddrTarget[int]).Pointer()
+		jumpAddr, genericInfoAddr := GetGenericAddr(addr, 10000)
+		convey.So(jumpAddr, convey.ShouldNotEqual, uintptr(0))
+		convey.So(genericInfoAddr, convey.ShouldNotEqual, uintptr(0))
+	})
+}
+
+func TestDisassembleRVA23Instruction(t *testing.T) {
+	convey.Convey("TestDisassembleRVA23Instruction", t, func() {
+		// CZERO.EQZ X7, X6, X5 is part of the RVA23 Zicond extension.
+		code := uint32ToBytes(0x0e5353b3)
+		convey.So(Disassemble(code, len(code), true), convey.ShouldEqual, len(code))
+	})
+}
+
+func TestDisassembleFarJALUsesVeneer(t *testing.T) {
+	code := jal(riscv64Zero, 512)
+	if got := Disassemble(code, len(code), true); got != len(code) {
+		t.Fatalf("far JAL cutting point: got %d, want %d", got, len(code))
+	}
+}
+
+func TestDisassembleCompressedForwardBranch(t *testing.T) {
+	code := make([]byte, 32)
+	binary.LittleEndian.PutUint16(code, 0xc005) // C.BEQZ X8, +32
+	for pos := 2; pos < len(code); pos += 2 {
+		binary.LittleEndian.PutUint16(code[pos:], 0x0001) // C.NOP
+	}
+	if got := Disassemble(code, 2, true); got != len(code) {
+		t.Fatalf("compressed forward-branch cutting point: got %d, want %d", got, len(code))
+	}
+}
+
+func TestBuildProxyRelocatesExternalJump(t *testing.T) {
+	const (
+		targetAddr = uintptr(0x200000)
+		proxyAddr  = uintptr(0x4000000000)
+		callOffset = int32(0x400)
+	)
+
+	proxy := BuildProxy(targetAddr, proxyAddr, jal(riscv64Zero, callOffset))
+	instruction, err := riscv64asm.Decode(proxy)
+	if err != nil {
+		t.Fatalf("decode relocated JAL: %v", err)
+	}
+	if rd := instruction.Args[0].(riscv64asm.Reg); rd != riscv64asm.X0 {
+		t.Fatalf("relocated JAL link register: got %v, want X0", rd)
+	}
+	veneerOffset := int(instruction.Args[1].(riscv64asm.Simm).Imm)
+	if veneerOffset <= 4 || veneerOffset+24 > len(proxy) {
+		t.Fatalf("invalid JAL veneer offset %d for %d-byte proxy", veneerOffset, len(proxy))
+	}
+	gotTarget := binary.LittleEndian.Uint64(proxy[veneerOffset+16 : veneerOffset+24])
+	wantTarget := uint64(targetAddr + uintptr(callOffset))
+	if gotTarget != wantTarget {
+		t.Fatalf("JAL veneer target: got %#x, want %#x", gotTarget, wantTarget)
+	}
+}
+
+func TestBuildProxyRelocatesAUIPC(t *testing.T) {
+	const (
+		targetAddr = uintptr(0x200000)
+		proxyAddr  = uintptr(0x4000000000)
+		imm20      = int32(0x123)
+	)
+
+	proxy := BuildProxy(targetAddr, proxyAddr, auipc(10, imm20))
+	jump, err := riscv64asm.Decode(proxy)
+	if err != nil {
+		t.Fatalf("decode AUIPC replacement: %v", err)
+	}
+	if rd := jump.Args[0].(riscv64asm.Reg); rd != riscv64asm.X0 {
+		t.Fatalf("AUIPC replacement link register: got %v, want X0", rd)
+	}
+	veneerOffset := int(jump.Args[1].(riscv64asm.Simm).Imm)
+	if veneerOffset <= 4 || veneerOffset+24 > len(proxy) {
+		t.Fatalf("invalid AUIPC veneer offset %d for %d-byte proxy", veneerOffset, len(proxy))
+	}
+	gotValue := binary.LittleEndian.Uint64(proxy[veneerOffset+16 : veneerOffset+24])
+	wantValue := uint64(targetAddr + uintptr(imm20<<12))
+	if gotValue != wantValue {
+		t.Fatalf("AUIPC veneer value: got %#x, want %#x", gotValue, wantValue)
+	}
+
+	returnJump, err := riscv64asm.Decode(proxy[veneerOffset+8:])
+	if err != nil {
+		t.Fatalf("decode AUIPC veneer return: %v", err)
+	}
+	returnTarget := proxyAddr + uintptr(veneerOffset+8) +
+		uintptr(returnJump.Args[1].(riscv64asm.Simm).Imm)
+	if want := proxyAddr + 4; returnTarget != want {
+		t.Fatalf("AUIPC veneer return target: got %#x, want %#x", returnTarget, want)
+	}
+}
+
+func TestBuildProxyRelocatesInternalLiteralBase(t *testing.T) {
+	const (
+		targetAddr = uintptr(0x200000)
+		proxyAddr  = uintptr(0x4000000000)
+	)
+
+	proxy := BuildProxy(targetAddr, proxyAddr, BranchInto(0x123456789abcdef0))
+	jump, err := riscv64asm.Decode(proxy)
+	if err != nil {
+		t.Fatalf("decode internal-literal AUIPC replacement: %v", err)
+	}
+	veneerOffset := int(jump.Args[1].(riscv64asm.Simm).Imm)
+	if veneerOffset <= len(BranchInto(0)) || veneerOffset+24 > len(proxy) {
+		t.Fatalf("invalid internal-literal veneer offset %d for %d-byte proxy", veneerOffset, len(proxy))
+	}
+	gotBase := binary.LittleEndian.Uint64(proxy[veneerOffset+16 : veneerOffset+24])
+	if gotBase != uint64(proxyAddr) {
+		t.Fatalf("relocated internal-literal base: got %#x, want %#x", gotBase, proxyAddr)
+	}
+}
+
+func TestBuildPatchRelocatesCallAtCopyEnd(t *testing.T) {
+	const (
+		targetAddr = uintptr(0x200000)
+		proxyAddr  = uintptr(0x400000)
+		hookAddr   = uintptr(0x600000)
+	)
+
+	code := make([]byte, 0, 24)
+	for range 3 {
+		code = append(code, nop()...)
+	}
+	code = append(code, jal(riscv64RA, 12)...)
+	code = append(code, nop()...)
+	code = append(code, nop()...)
+
+	if got := PatchSize(targetAddr, code, true); got != len(code) {
+		t.Fatalf("patch size: got %d, want %d", got, len(code))
+	}
+
+	proxyCode, targetPatch := BuildPatch(targetAddr, proxyAddr, hookAddr, code)
+	call, err := riscv64asm.Decode(proxyCode[12:])
+	if err != nil {
+		t.Fatalf("decode relocated call: %v", err)
+	}
+	veneerOffset := 12 + int(call.Args[1].(riscv64asm.Simm).Imm)
+	if veneerOffset <= len(code) || veneerOffset+40 > len(proxyCode) {
+		t.Fatalf("invalid call veneer offset %d for %d-byte proxy", veneerOffset, len(proxyCode))
+	}
+	if got, want := binary.LittleEndian.Uint64(proxyCode[veneerOffset+24:]), uint64(targetAddr+16); got != want {
+		t.Fatalf("call return PC: got %#x, want %#x", got, want)
+	}
+	if got, want := binary.LittleEndian.Uint64(proxyCode[veneerOffset+32:]), uint64(targetAddr+24); got != want {
+		t.Fatalf("call target: got %#x, want %#x", got, want)
+	}
+	plan, ok := makePatchPlan(code)
+	if !ok {
+		t.Fatal("return gateway plan failed")
+	}
+	gateway := plan.gateways[riscv64RA]
+	if got, want := targetPatch[16:20], shortJump(4, targetAddr+16, targetAddr+uintptr(gateway.start)); !bytes.Equal(got, want) {
+		t.Fatalf("return landing: got %x, want %x", got, want)
+	}
+}
+
+func TestAllocateProxySupportsManyConcurrentPages(t *testing.T) {
+	const proxyCount = 70
+
+	targetAddr := reflect.ValueOf(genericAddrTarget[int]).Pointer()
+	proxies := make([][]byte, 0, proxyCount)
+	defer func() {
+		for index := len(proxies) - 1; index >= 0; index-- {
+			ReleaseProxy(proxies[index])
+		}
+	}()
+
+	seen := make(map[uintptr]struct{}, proxyCount)
+	for index := 0; index < proxyCount; index++ {
+		proxy := AllocateProxy(targetAddr)
+		address := common.PtrOf(proxy)
+		if _, ok := seen[address]; ok {
+			t.Fatalf("proxy %d reused live address %#x", index, address)
+		}
+		seen[address] = struct{}{}
+		if len(proxy) == 0 {
+			t.Fatalf("proxy %d has zero length", index)
+		}
+		if _, _, ok := pcRelativeParts(targetAddr, address+uintptr(len(proxy)-1)); !ok {
+			t.Fatalf("proxy %d at %#x is outside AUIPC/JALR range of %#x", index, address, targetAddr)
+		}
+		proxies = append(proxies, proxy)
+	}
+}
+
+func TestGenericJumpUsesLocalCompressedOffsetDecoder(t *testing.T) {
+	code := cJ(6)
+	instruction, err := riscv64asm.Decode(code)
+	if err != nil {
+		t.Fatalf("decode C.J: %v", err)
+	}
+	address := common.PtrOf(code)
+	jump := &genericJmpInst{
+		posInst: &posInst{addr: address, inst: instruction},
+	}
+	if got, want := jump.calcJumpAddr(nil), address+6; got != want {
+		t.Fatalf("generic C.J target: got %#x, want %#x", got, want)
+	}
+}
+
+func TestGenericScannerIgnoresX5LinkCalls(t *testing.T) {
+	// GetGenericAddr looks for the wrapper's single business call. Go uses X5
+	// for compiler-inserted morestack calls, so those must not become a second
+	// generic target. Proxy relocation classifies X5 independently.
+	for _, encoding := range [][]byte{
+		jal(int(riscv64asm.X5), 8),
+		jalr(int(riscv64asm.X5), 10, 0),
+	} {
+		instruction, err := riscv64asm.Decode(encoding)
+		if err != nil {
+			t.Fatalf("decode X5 call: %v", err)
+		}
+		if isCall(instruction) {
+			t.Fatalf("generic scanner classified X5 instruction as business call: %v", instruction)
+		}
+	}
+
+	instruction, err := riscv64asm.Decode(jal(riscv64RA, 8))
+	if err != nil {
+		t.Fatalf("decode X1 call: %v", err)
+	}
+	if !isCall(instruction) {
+		t.Fatalf("generic scanner missed X1 business call: %v", instruction)
+	}
+}
+
+func TestGenericJumpClassifiesPCRelativeTrampoline(t *testing.T) {
+	code := make([]byte, 24)
+	copy(code, jal(riscv64RA, 8))
+	copy(code[8:], auipc(int(riscv64asm.X31), 0))
+	copy(code[12:], jalr(riscv64Zero, int(riscv64asm.X31), 8))
+
+	base := common.PtrOf(code)
+	target := base + 16
+	const helperName = "runtime helper behind linker trampoline"
+	oldName, existed := proxyCallRace[target]
+	proxyCallRace[target] = helperName
+	t.Cleanup(func() {
+		if existed {
+			proxyCallRace[target] = oldName
+		} else {
+			delete(proxyCallRace, target)
+		}
+	})
+
+	instruction, err := riscv64asm.Decode(code)
+	if err != nil {
+		t.Fatalf("decode call to trampoline: %v", err)
+	}
+	jump := newGenericJmpInst(base, 0, instruction, nil)
+	if got, want := jump.jumpAddr, base+8; got != want {
+		t.Fatalf("generic call target: got %#x, want trampoline %#x", got, want)
+	}
+	if !jump.isExtraCall || jump.extraCallName != helperName {
+		t.Fatalf("generic trampoline classification: got extra=%v name=%q", jump.isExtraCall, jump.extraCallName)
+	}
+}
+
+func TestGetGenericAddrStopsAtPartialInstructionBoundary(t *testing.T) {
+	code := make([]byte, 24)
+	copy(code, jal(riscv64RA, 16))
+	copy(code[4:], nop())
+	copy(code[8:], nop())
+
+	base := common.PtrOf(code)
+	jumpAddr, genericInfoAddr := GetGenericAddr(base, 10)
+	if got, want := jumpAddr, base+16; got != want {
+		t.Fatalf("generic call target: got %#x, want %#x", got, want)
+	}
+	if genericInfoAddr != 0 {
+		t.Fatalf("generic info address without AUIPC/ADDI: got %#x, want 0", genericInfoAddr)
+	}
+}

--- a/internal/monkey/inst/proxy_boundary_riscv64.go
+++ b/internal/monkey/inst/proxy_boundary_riscv64.go
@@ -1,0 +1,109 @@
+//go:build linux && riscv64
+// +build linux,riscv64
+
+/*
+ * Copyright 2022 ByteDance Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package inst
+
+import (
+	"github.com/bytedance/mockey/internal/tool"
+	"golang.org/x/arch/riscv64/riscv64asm"
+)
+
+// extendTMPSequence prevents the proxy's tail jump from clobbering X31 in the
+// middle of a multi-instruction expansion emitted by the Go assembler.
+func extendTMPSequence(code []byte, limit int) int {
+	active := false
+	maxEnd := limit
+	var scan reachableCodeScan
+	for pos := 0; ; {
+		tool.Assert(pos < len(code), "RISC-V TMP sequence exceeds patch scan buffer")
+		instruction, err := riscv64asm.Decode(code[pos:])
+		tool.Assert(err == nil, "decode TMP sequence at +%d: %v", pos, err)
+		scan.observe(pos, instruction, code[pos:])
+
+		writesTMP := instructionWritesTMP(instruction)
+		readsTMP := instructionReadsTMP(instruction, writesTMP)
+		switch {
+		case writesTMP:
+			active = true
+		case active && readsTMP:
+			active = false
+		}
+
+		end := pos + instruction.Len
+		maxEnd = max(maxEnd, end)
+		if active {
+			_, conditional := conditionalBranchTarget(pos, instruction)
+			tool.Assert(
+				!conditional && instruction.Op != riscv64asm.JAL && instruction.Op != riscv64asm.JALR,
+				"RISC-V TMP sequence crosses control flow at +%d",
+				pos,
+			)
+			pos = end
+			continue
+		}
+
+		nextPos, stop := scan.advance(pos, instruction, limit)
+		if stop {
+			return maxEnd
+		}
+		pos = nextPos
+		if pos >= limit {
+			return max(maxEnd, pos)
+		}
+	}
+}
+
+func instructionWritesTMP(instruction riscv64asm.Inst) bool {
+	if !firstRegisterIsTMP(instruction) {
+		return false
+	}
+	switch instruction.Op {
+	case riscv64asm.BEQ, riscv64asm.BNE, riscv64asm.BLT, riscv64asm.BGE,
+		riscv64asm.BLTU, riscv64asm.BGEU,
+		riscv64asm.SB, riscv64asm.SH, riscv64asm.SW, riscv64asm.SD,
+		riscv64asm.FSW, riscv64asm.FSD:
+		return false
+	default:
+		return true
+	}
+}
+
+func instructionReadsTMP(instruction riscv64asm.Inst, firstIsDestination bool) bool {
+	for index, argument := range instruction.Args {
+		if firstIsDestination && index == 0 {
+			continue
+		}
+		switch value := argument.(type) {
+		case riscv64asm.Reg:
+			if value == riscv64asm.X31 {
+				return true
+			}
+		case riscv64asm.RegOffset:
+			if value.OfsReg == riscv64asm.X31 {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func firstRegisterIsTMP(instruction riscv64asm.Inst) bool {
+	register, ok := instruction.Args[0].(riscv64asm.Reg)
+	return ok && register == riscv64asm.X31
+}

--- a/internal/monkey/inst/proxy_other.go
+++ b/internal/monkey/inst/proxy_other.go
@@ -1,0 +1,49 @@
+//go:build amd64 || arm64
+// +build amd64 arm64
+
+/*
+ * Copyright 2022 ByteDance Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package inst
+
+import "github.com/bytedance/mockey/internal/monkey/common"
+
+const maxPatchSize = 64
+
+func MaxPatchSize() int {
+	return maxPatchSize
+}
+
+func AllocateProxy(_ uintptr) []byte {
+	return common.AllocatePage()
+}
+
+func ReleaseProxy(proxy []byte) {
+	common.ReleasePage(proxy)
+}
+
+func PatchSize(_ uintptr, code []byte, checkLen bool) int {
+	return Disassemble(code, len(BranchInto(0)), checkLen)
+}
+
+func BuildPatch(targetAddr, proxyAddr, hookAddr uintptr, code []byte) (proxy, targetPatch []byte) {
+	return BuildProxy(targetAddr, proxyAddr, code), BranchInto(hookAddr)
+}
+
+func BuildProxy(targetAddr, _ uintptr, code []byte) []byte {
+	proxy := append([]byte(nil), code...)
+	return append(proxy, BranchTo(targetAddr+uintptr(len(code)))...)
+}

--- a/internal/monkey/inst/proxy_relocation_riscv64_test.go
+++ b/internal/monkey/inst/proxy_relocation_riscv64_test.go
@@ -1,0 +1,1024 @@
+//go:build linux && riscv64
+// +build linux,riscv64
+
+/*
+ * Copyright 2022 ByteDance Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package inst
+
+import (
+	"bytes"
+	"encoding/binary"
+	"fmt"
+	"strings"
+	"testing"
+
+	"golang.org/x/arch/riscv64/riscv64asm"
+)
+
+func nopCode(size int) []byte {
+	code := make([]byte, 0, size)
+	for len(code)+4 <= size {
+		code = append(code, nop()...)
+	}
+	if len(code) < size {
+		code = append(code, 0x01, 0x00) // C.NOP
+	}
+	return code
+}
+
+func decodedJumpTarget(t *testing.T, code []byte, pc uintptr) (uintptr, riscv64asm.Inst) {
+	t.Helper()
+	instruction, err := riscv64asm.Decode(code)
+	if err != nil {
+		t.Fatalf("decode jump at %#x: %v", pc, err)
+	}
+	if instruction.Op != riscv64asm.JAL {
+		t.Fatalf("instruction at %#x: got %v, want JAL", pc, instruction.Op)
+	}
+	var offset int64
+	if instruction.Len == 2 {
+		offset = int64(decodeCJOffset(code))
+	} else {
+		offset = int64(instruction.Args[1].(riscv64asm.Simm).Imm)
+	}
+	return uintptr(int64(pc) + offset), instruction
+}
+
+func decodedPCRelativeTarget(t *testing.T, code []byte, pc uintptr) uintptr {
+	t.Helper()
+	high, err := riscv64asm.Decode(code)
+	if err != nil || high.Op != riscv64asm.AUIPC {
+		t.Fatalf("decode gateway AUIPC at %#x: %v, %v", pc, high.Op, err)
+	}
+	low, err := riscv64asm.Decode(code[high.Len:])
+	if err != nil || low.Op != riscv64asm.JALR {
+		t.Fatalf("decode gateway JALR at %#x: %v, %v", pc+uintptr(high.Len), low.Op, err)
+	}
+	offset := low.Args[1].(riscv64asm.RegOffset)
+	return uintptr(int64(pc) + auipcImm(high) + int64(offset.Ofs.Imm))
+}
+
+func compressedJALR(rs1 int) []byte {
+	return uint16ToBytes(uint16(0x9002 | rs1<<7))
+}
+
+func TestBuildProxyAlignsTailLiteral(t *testing.T) {
+	const (
+		targetAddr = uintptr(0x200000)
+		proxyAddr  = uintptr(0x400000)
+	)
+	for _, codeSize := range []int{24, 26, 30} {
+		t.Run(fmt.Sprint(codeSize), func(t *testing.T) {
+			code := nopCode(codeSize)
+			proxy := BuildProxy(targetAddr, proxyAddr, code)
+			tailOffset := (codeSize + 7) &^ 7
+			if got := proxyAddr + uintptr(tailOffset+16); got%8 != 0 {
+				t.Fatalf("tail literal address %#x is not 8-byte aligned", got)
+			}
+			if got, want := binary.LittleEndian.Uint64(proxy[tailOffset+16:tailOffset+24]), uint64(targetAddr+uintptr(codeSize)); got != want {
+				t.Fatalf("tail target: got %#x, want %#x", got, want)
+			}
+			for offset := codeSize; offset < tailOffset; offset += 2 {
+				if got := binary.LittleEndian.Uint16(proxy[offset:]); got != 0x0001 {
+					t.Fatalf("padding at +%d: got %#x, want C.NOP", offset, got)
+				}
+			}
+		})
+	}
+}
+
+func TestCompressedJumpEncoding(t *testing.T) {
+	for _, offset := range []int32{-2048, -2, 2, 2046} {
+		instruction, err := riscv64asm.Decode(cJ(offset))
+		if err != nil {
+			t.Fatalf("decode C.J %d: %v", offset, err)
+		}
+		if instruction.Len != 2 || instruction.Op != riscv64asm.JAL {
+			t.Fatalf("C.J %d decoded as %v length %d", offset, instruction.Op, instruction.Len)
+		}
+		if got := decodeCJOffset(cJ(offset)); got != offset {
+			t.Fatalf("C.J immediate: got %d, want %d", got, offset)
+		}
+	}
+}
+
+func TestPCRelativeParts(t *testing.T) {
+	for _, test := range []struct {
+		from uintptr
+		to   uintptr
+	}{
+		{from: 0x1000, to: 0x1000},
+		{from: 0x400000, to: 0x200000},
+		{from: 0x200000, to: 0x40123456},
+	} {
+		high, low, ok := pcRelativeParts(test.from, test.to)
+		if !ok {
+			t.Fatalf("pcRelativeParts(%#x, %#x) failed", test.from, test.to)
+		}
+		if got := int64(test.from) + int64(high)<<12 + int64(low); got != int64(test.to) {
+			t.Fatalf("reconstructed target: got %#x, want %#x", got, test.to)
+		}
+	}
+	if _, _, ok := pcRelativeParts(0x1000, 0x1000+(1<<31)); ok {
+		t.Fatal("accepted an out-of-range positive AUIPC/JALR target")
+	}
+}
+
+func TestExtendTMPSequence(t *testing.T) {
+	code := append(auipc(riscv64TMP, 1), ld(10, riscv64TMP, 0)...)
+	code = append(code, nop()...)
+	if got := extendTMPSequence(code, 4); got != 8 {
+		t.Fatalf("TMP sequence boundary: got %d, want 8", got)
+	}
+	if got := extendTMPSequence(nopCode(8), 4); got != 4 {
+		t.Fatalf("plain boundary: got %d, want 4", got)
+	}
+}
+
+func TestBuildProxyRejectsExternalConditionalBranch(t *testing.T) {
+	// BEQ X0, X0, +16.
+	code := append(uint32ToBytes(0x00000863), nop()...)
+	defer func() {
+		if recover() == nil {
+			t.Fatal("external conditional branch did not panic")
+		}
+	}()
+	BuildProxy(0x200000, 0x400000, code)
+}
+
+func TestBuildPatchRelocatesAdjacentCalls(t *testing.T) {
+	const (
+		targetAddr = uintptr(0x200000)
+		proxyAddr  = uintptr(0x400000)
+		hookAddr   = uintptr(0x600000)
+	)
+	code := nopCode(32)
+	copy(code[8:], jal(riscv64RA, 0x400))
+	copy(code[12:], jal(riscv64RA, 0x500))
+
+	patchSize := PatchSize(targetAddr, code, true)
+	if patchSize != len(code) {
+		t.Fatalf("patch size: got %d, want %d", patchSize, len(code))
+	}
+	proxy, targetPatch := BuildPatch(targetAddr, proxyAddr, hookAddr, code[:patchSize])
+	plan, ok := makePatchPlan(code[:patchSize])
+	if !ok {
+		t.Fatal("return gateway plan failed")
+	}
+	if len(plan.landings) != 2 {
+		t.Fatalf("return landings: got %d, want 2", len(plan.landings))
+	}
+	gateway := plan.gateways[riscv64RA]
+
+	for index, call := range []struct {
+		pos    int
+		offset int32
+	}{
+		{pos: 8, offset: 0x400},
+		{pos: 12, offset: 0x500},
+	} {
+		returnPos := call.pos + 4
+		landingTarget, landing := decodedJumpTarget(
+			t,
+			targetPatch[returnPos:],
+			targetAddr+uintptr(returnPos),
+		)
+		if landing.Len != 4 || landing.Args[0].(riscv64asm.Reg) != riscv64asm.X0 {
+			t.Fatalf("landing %d: got %v, want 4-byte JAL X0", index, landing)
+		}
+		if want := targetAddr + uintptr(gateway.start); landingTarget != want {
+			t.Fatalf("landing %d target: got %#x, want %#x", index, landingTarget, want)
+		}
+
+		veneerAddr, source := decodedJumpTarget(
+			t,
+			proxy[call.pos:],
+			proxyAddr+uintptr(call.pos),
+		)
+		if source.Args[0].(riscv64asm.Reg) != riscv64asm.X0 {
+			t.Fatalf("source call %d writes %v, want X0", index, source.Args[0])
+		}
+		veneerOffset := int(veneerAddr - proxyAddr)
+		if got, want := binary.LittleEndian.Uint64(proxy[veneerOffset+24:]), uint64(targetAddr+uintptr(returnPos)); got != want {
+			t.Fatalf("call %d return PC: got %#x, want %#x", index, got, want)
+		}
+		if got, want := binary.LittleEndian.Uint64(proxy[veneerOffset+32:]), uint64(int64(targetAddr+uintptr(call.pos))+int64(call.offset)); got != want {
+			t.Fatalf("call %d target: got %#x, want %#x", index, got, want)
+		}
+	}
+
+	dispatcherAddr := decodedPCRelativeTarget(
+		t,
+		targetPatch[gateway.start:gateway.end],
+		targetAddr+uintptr(gateway.start),
+	)
+	dispatcherOffset := int(dispatcherAddr - proxyAddr)
+	if dispatcherOffset < 0 || dispatcherOffset+24 > len(proxy) {
+		t.Fatalf("dispatcher offset %d is outside %d-byte proxy", dispatcherOffset, len(proxy))
+	}
+	if got, want := binary.LittleEndian.Uint64(proxy[dispatcherOffset+16:]), uint64(proxyAddr-targetAddr); got != want {
+		t.Fatalf("dispatcher delta: got %#x, want %#x", got, want)
+	}
+}
+
+func TestBuildPatchRelocatesIndirectCalls(t *testing.T) {
+	const (
+		targetAddr = uintptr(0x200000)
+		proxyAddr  = uintptr(0x400000)
+		hookAddr   = uintptr(0x600000)
+	)
+	for _, test := range []struct {
+		name    string
+		linkReg int
+		baseReg int
+		offset  int32
+	}{
+		{name: "RA", linkReg: riscv64RA, baseReg: 10, offset: 12},
+		{name: "same register", linkReg: riscv64RA, baseReg: riscv64RA, offset: 12},
+		{name: "X5", linkReg: int(riscv64asm.X5), baseReg: riscv64TMP, offset: 0},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			code := nopCode(32)
+			copy(code[8:], jalr(test.linkReg, test.baseReg, test.offset))
+			patchSize := PatchSize(targetAddr, code, true)
+			proxy, targetPatch := BuildPatch(
+				targetAddr,
+				proxyAddr,
+				hookAddr,
+				code[:patchSize],
+			)
+
+			veneerAddr, source := decodedJumpTarget(t, proxy[8:], proxyAddr+8)
+			if source.Args[0].(riscv64asm.Reg) != riscv64asm.X0 {
+				t.Fatalf("proxy source writes %v, want X0", source.Args[0])
+			}
+			veneerOffset := int(veneerAddr - proxyAddr)
+			veneer := proxy[veneerOffset:]
+			auipcOffset := 0
+			if test.linkReg == test.baseReg {
+				capture, err := riscv64asm.Decode(veneer)
+				if err != nil || capture.Op != riscv64asm.ADDI {
+					t.Fatalf("decode target capture: %v, %v", capture.Op, err)
+				}
+				if got := capture.Args[0].(riscv64asm.Reg); got != riscv64asm.X31 {
+					t.Fatalf("capture destination: got %v, want X31", got)
+				}
+				auipcOffset = capture.Len
+			}
+
+			high, err := riscv64asm.Decode(veneer[auipcOffset:])
+			if err != nil || high.Op != riscv64asm.AUIPC {
+				t.Fatalf("decode return AUIPC: %v, %v", high.Op, err)
+			}
+			low, err := riscv64asm.Decode(veneer[auipcOffset+high.Len:])
+			if err != nil || low.Op != riscv64asm.ADDI {
+				t.Fatalf("decode return ADDI: %v, %v", low.Op, err)
+			}
+			gotReturn := int64(veneerAddr+uintptr(auipcOffset)) +
+				auipcImm(high) +
+				int64(low.Args[2].(riscv64asm.Simm).Imm)
+			if want := int64(targetAddr + 12); gotReturn != want {
+				t.Fatalf("indirect return PC: got %#x, want %#x", gotReturn, want)
+			}
+			jumpOffset := auipcOffset + high.Len + low.Len
+			jump, err := riscv64asm.Decode(veneer[jumpOffset:])
+			if err != nil || jump.Op != riscv64asm.JALR {
+				t.Fatalf("decode indirect jump: %v, %v", jump.Op, err)
+			}
+			jumpBase := jump.Args[1].(riscv64asm.RegOffset)
+			if test.linkReg == test.baseReg {
+				if jumpBase.OfsReg != riscv64asm.X31 || jumpBase.Ofs.Imm != 0 {
+					t.Fatalf("same-register jump base: got %v", jumpBase)
+				}
+			} else if int(jumpBase.OfsReg) != test.baseReg || jumpBase.Ofs.Imm != test.offset {
+				t.Fatalf("indirect jump base: got %v, want X%d+%d", jumpBase, test.baseReg, test.offset)
+			}
+
+			plan, ok := makePatchPlan(code[:patchSize])
+			if !ok {
+				t.Fatal("return gateway plan failed")
+			}
+			gateway := plan.gateways[test.linkReg]
+			landingTarget, landing := decodedJumpTarget(t, targetPatch[12:], targetAddr+12)
+			if landing.Len != 4 || landingTarget != targetAddr+uintptr(gateway.start) {
+				t.Fatalf("indirect return landing: got %v to %#x", landing, landingTarget)
+			}
+		})
+	}
+}
+
+func TestBuildProxyRelocatesExternalCompressedJump(t *testing.T) {
+	const (
+		targetAddr = uintptr(0x200000)
+		proxyAddr  = uintptr(0x400000)
+	)
+	code := append(cJ(0x400), nopCode(22)...)
+	proxy := BuildProxy(targetAddr, proxyAddr, code)
+	veneerAddr, source := decodedJumpTarget(t, proxy, proxyAddr)
+	if source.Len != 2 || source.Args[0].(riscv64asm.Reg) != riscv64asm.X0 {
+		t.Fatalf("compressed source: got %v, want 2-byte JAL X0", source)
+	}
+	veneerOffset := int(veneerAddr - proxyAddr)
+	if got, want := binary.LittleEndian.Uint64(proxy[veneerOffset+16:]), uint64(targetAddr+0x400); got != want {
+		t.Fatalf("compressed jump target: got %#x, want %#x", got, want)
+	}
+}
+
+func TestBuildPatchRelocatesCompressedIndirectCall(t *testing.T) {
+	const (
+		targetAddr = uintptr(0x200000)
+		proxyAddr  = uintptr(0x400000)
+		hookAddr   = uintptr(0x600000)
+	)
+	code := nopCode(8)
+	code = append(code, compressedJALR(10)...)
+	code = append(code, 0x01, 0x00) // C.NOP
+	code = append(code, nopCode(20)...)
+
+	patchSize := PatchSize(targetAddr, code, true)
+	proxy, targetPatch := BuildPatch(targetAddr, proxyAddr, hookAddr, code[:patchSize])
+	veneerAddr, source := decodedJumpTarget(t, proxy[8:], proxyAddr+8)
+	if source.Len != 2 || source.Args[0].(riscv64asm.Reg) != riscv64asm.X0 {
+		t.Fatalf("compressed indirect source: got %v, want C.J", source)
+	}
+	veneerOffset := int(veneerAddr - proxyAddr)
+	high, err := riscv64asm.Decode(proxy[veneerOffset:])
+	if err != nil || high.Op != riscv64asm.AUIPC {
+		t.Fatalf("decode compressed-call return AUIPC: %v, %v", high.Op, err)
+	}
+	low, err := riscv64asm.Decode(proxy[veneerOffset+high.Len:])
+	if err != nil || low.Op != riscv64asm.ADDI {
+		t.Fatalf("decode compressed-call return ADDI: %v, %v", low.Op, err)
+	}
+	gotReturn := int64(veneerAddr) +
+		auipcImm(high) +
+		int64(low.Args[2].(riscv64asm.Simm).Imm)
+	if want := int64(targetAddr + 10); gotReturn != want {
+		t.Fatalf("compressed call return PC: got %#x, want %#x", gotReturn, want)
+	}
+	jump, err := riscv64asm.Decode(proxy[veneerOffset+high.Len+low.Len:])
+	if err != nil || jump.Op != riscv64asm.JALR {
+		t.Fatalf("decode compressed indirect target jump: %v, %v", jump.Op, err)
+	}
+	if base := jump.Args[1].(riscv64asm.RegOffset); base.OfsReg != riscv64asm.X10 || base.Ofs.Imm != 0 {
+		t.Fatalf("compressed indirect target base: got %v, want X10", base)
+	}
+
+	plan, ok := makePatchPlan(code[:patchSize])
+	if !ok {
+		t.Fatal("compressed return gateway plan failed")
+	}
+	gateway := plan.gateways[riscv64RA]
+	landingTarget, landing := decodedJumpTarget(t, targetPatch[10:], targetAddr+10)
+	if landing.Len != 4 || landingTarget != targetAddr+uintptr(gateway.start) {
+		t.Fatalf("compressed return landing: got %v to %#x", landing, landingTarget)
+	}
+}
+
+func assertPanicContains(t *testing.T, want string, fn func()) {
+	t.Helper()
+	defer func() {
+		value := recover()
+		if value == nil {
+			t.Fatalf("operation did not panic; want message containing %q", want)
+		}
+		if got := fmt.Sprint(value); !strings.Contains(got, want) {
+			t.Fatalf("panic: got %q, want substring %q", got, want)
+		}
+	}()
+	fn()
+}
+
+func beqOffset(offset int32) []byte {
+	immediate := uint32(offset)
+	instruction := ((immediate >> 12) & 0x1 << 31) |
+		((immediate >> 5) & 0x3f << 25) |
+		((immediate >> 1) & 0xf << 8) |
+		((immediate >> 11) & 0x1 << 7) |
+		0x63
+	return uint32ToBytes(instruction)
+}
+
+func chainedForwardPrefix(size int) []byte {
+	code := nopCode(size)
+	for pos := 0; pos+4 < size; {
+		target := pos + 4092
+		if target > size {
+			target = size
+		}
+		copy(code[pos:], beqOffset(int32(target-pos)))
+		if target == size {
+			break
+		}
+		pos = target - 4
+	}
+	return code
+}
+
+func TestBuildPatchMixedCallLandingSizes(t *testing.T) {
+	const (
+		targetAddr = uintptr(0x200000)
+		proxyAddr  = uintptr(0x400000)
+		hookAddr   = uintptr(0x600000)
+	)
+
+	jalThenCompressed := nopCode(32)
+	copy(jalThenCompressed[8:], jal(riscv64RA, 0x400))
+	copy(jalThenCompressed[12:], compressedJALR(10))
+	copy(jalThenCompressed[14:], []byte{0x01, 0x00})
+
+	compressedThenJAL := nopCode(32)
+	copy(compressedThenJAL[8:], compressedJALR(10))
+	copy(compressedThenJAL[10:], jal(riscv64RA, 0x400))
+	copy(compressedThenJAL[14:], []byte{0x01, 0x00})
+
+	for _, test := range []struct {
+		name string
+		code []byte
+		want []codeRange
+	}{
+		{
+			name: "JAL then C.JALR",
+			code: jalThenCompressed,
+			want: []codeRange{{start: 12, end: 14}, {start: 14, end: 18}},
+		},
+		{
+			name: "C.JALR then JAL",
+			code: compressedThenJAL,
+			want: []codeRange{{start: 10, end: 14}, {start: 14, end: 18}},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			patchSize := PatchSize(targetAddr, test.code, true)
+			_, targetPatch := BuildPatch(
+				targetAddr,
+				proxyAddr,
+				hookAddr,
+				test.code[:patchSize],
+			)
+			plan, ok := makePatchPlan(test.code[:patchSize])
+			if !ok {
+				t.Fatal("mixed-width return gateway plan failed")
+			}
+			if len(plan.landings) != len(test.want) {
+				t.Fatalf("landings: got %v, want %v", plan.landings, test.want)
+			}
+			for index, want := range test.want {
+				landing := plan.landings[index]
+				if landing.start != want.start || landing.end != want.end {
+					t.Fatalf("landing %d: got [%d,%d), want [%d,%d)",
+						index, landing.start, landing.end, want.start, want.end)
+				}
+				if index+1 < len(plan.landings) &&
+					landing.end > plan.landings[index+1].start {
+					t.Fatalf("landing %d overlaps landing %d", index, index+1)
+				}
+				gateway := plan.gateways[landing.linkReg]
+				gotTarget, instruction := decodedJumpTarget(
+					t,
+					targetPatch[landing.start:],
+					targetAddr+uintptr(landing.start),
+				)
+				if instruction.Len != landing.size() {
+					t.Fatalf("landing %d jump length: got %d, want %d",
+						index, instruction.Len, landing.size())
+				}
+				if wantTarget := targetAddr + uintptr(gateway.start); gotTarget != wantTarget {
+					t.Fatalf("landing %d target: got %#x, want %#x",
+						index, gotTarget, wantTarget)
+				}
+			}
+		})
+	}
+}
+
+func TestBuildPatchRelocatesInternalDirectCallToProxy(t *testing.T) {
+	const (
+		targetAddr = uintptr(0x200000)
+		proxyAddr  = uintptr(0x400000)
+		hookAddr   = uintptr(0x600000)
+	)
+	code := nopCode(24)
+	copy(code[16:], jal(riscv64RA, -8))
+
+	patchSize := PatchSize(targetAddr, code, true)
+	proxy, _ := BuildPatch(targetAddr, proxyAddr, hookAddr, code[:patchSize])
+	plan, ok := makePatchPlan(code[:patchSize])
+	if !ok {
+		t.Fatal("internal-call gateway plan failed")
+	}
+	if gateway := plan.gateways[riscv64RA]; gateway.start != 8 {
+		t.Fatalf("gateway: got [%d,%d), want local callee slot [8,16)",
+			gateway.start, gateway.end)
+	}
+
+	veneerAddr, _ := decodedJumpTarget(t, proxy[16:], proxyAddr+16)
+	veneerOffset := int(veneerAddr - proxyAddr)
+	if got, want := binary.LittleEndian.Uint64(proxy[veneerOffset+32:]), uint64(proxyAddr+8); got != want {
+		t.Fatalf("internal callee target: got %#x, want proxy target %#x", got, want)
+	}
+}
+
+func TestBuildPatchRelocatesAUIPCCallTarget(t *testing.T) {
+	const (
+		targetAddr = uintptr(0x200000)
+		proxyAddr  = uintptr(0x400000)
+		hookAddr   = uintptr(0x600000)
+	)
+	for _, test := range []struct {
+		name       string
+		auipcImm   int32
+		jalrOffset int32
+		wantBase   uintptr
+		internal   bool
+	}{
+		{
+			name:       "internal",
+			auipcImm:   0,
+			jalrOffset: -4,
+			wantBase:   proxyAddr + 12,
+			internal:   true,
+		},
+		{
+			name:       "external",
+			auipcImm:   1,
+			jalrOffset: 0,
+			wantBase:   targetAddr + 12 + 1<<12,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			code := nopCode(32)
+			copy(code[12:], auipc(10, test.auipcImm))
+			copy(code[16:], jalr(riscv64RA, 10, test.jalrOffset))
+
+			patchSize := PatchSize(targetAddr, code, true)
+			proxy, _ := BuildPatch(
+				targetAddr,
+				proxyAddr,
+				hookAddr,
+				code[:patchSize],
+			)
+			veneerAddr, _ := decodedJumpTarget(t, proxy[12:], proxyAddr+12)
+			veneerOffset := int(veneerAddr - proxyAddr)
+			if got := uintptr(binary.LittleEndian.Uint64(proxy[veneerOffset+16:])); got != test.wantBase {
+				t.Fatalf("AUIPC call base: got %#x, want %#x", got, test.wantBase)
+			}
+
+			if test.internal {
+				plan, ok := makePatchPlan(code[:patchSize])
+				if !ok {
+					t.Fatal("internal AUIPC/JALR gateway plan failed")
+				}
+				if gateway := plan.gateways[riscv64RA]; gateway.start != 8 {
+					t.Fatalf("gateway: got [%d,%d), want local callee slot [8,16)",
+						gateway.start, gateway.end)
+				}
+			}
+		})
+	}
+}
+
+func TestBuildProxyRejectsLongCompressedJump(t *testing.T) {
+	code := append(cJ(2046), nopCode(2022)...)
+	assertPanicContains(t, "compressed call/jump", func() {
+		BuildProxy(0x200000, 0x400000, code)
+	})
+}
+
+func TestBuildProxyRejectsFullPagePrefix(t *testing.T) {
+	code := nopCode(MaxPatchSize())
+	assertPanicContains(t, "exceeds the", func() {
+		BuildProxy(0x200000, 0x400000, code)
+	})
+}
+
+func TestPatchSizeRejectsPrefixWithoutProxyCapacity(t *testing.T) {
+	code := chainedForwardPrefix(MaxPatchSize())
+	assertPanicContains(t, "exceeds the", func() {
+		PatchSize(0x200000, code, true)
+	})
+}
+
+func TestPatchSizeRejectsDistantCompressedCallClusters(t *testing.T) {
+	code := chainedForwardPrefix(8192)
+	copy(code[8:], compressedJALR(10))
+	copy(code[10:], compressedJALR(11))
+	copy(code[8176:], compressedJALR(10))
+	copy(code[8178:], compressedJALR(11))
+
+	assertPanicContains(t, "no common +/-2 KiB gateway range", func() {
+		PatchSize(0x200000, code, true)
+	})
+}
+
+func TestPatchSizeRejectsNoProgress(t *testing.T) {
+	assertPanicContains(t, "did not reach the initial prefix", func() {
+		PatchSize(0x200000, nil, false)
+	})
+}
+
+func TestProxyMappingReachabilityChecksBothDirectionsAndOverflow(t *testing.T) {
+	const pageSize = uintptr(64 << 10)
+	if !proxyMappingReachable(0x40000000, pageSize, 0x50000000, pageSize) {
+		t.Fatal("rejected nearby 64 KiB target/proxy ranges")
+	}
+
+	const target = uintptr(0x100000000)
+	const asymmetricDistance = uintptr(2147483000)
+	proxy := target - asymmetricDistance
+	if _, _, ok := pcRelativeParts(target, proxy); !ok {
+		t.Fatal("test setup: negative direction should be encodable")
+	}
+	if _, _, ok := pcRelativeParts(proxy, target); ok {
+		t.Fatal("test setup: positive reverse direction should be out of range")
+	}
+	if proxyMappingReachable(target, 1, proxy, 1) {
+		t.Fatal("accepted mapping reachable only in the forward direction")
+	}
+
+	if proxyMappingReachable(^uintptr(0)-8, 16, 0x1000, pageSize) {
+		t.Fatal("accepted overflowing target range")
+	}
+	if proxyMappingReachable(0x1000, pageSize, ^uintptr(0)-8, 16) {
+		t.Fatal("accepted overflowing proxy range")
+	}
+
+	highAddress := ^uintptr(0) - 0x1000
+	if _, _, ok := pcRelativeParts(highAddress, 0x1000); ok {
+		t.Fatal("accepted wrapped high-to-low PC-relative difference")
+	}
+	if _, _, ok := pcRelativeParts(0x1000, highAddress); ok {
+		t.Fatal("accepted wrapped low-to-high PC-relative difference")
+	}
+	if proxyMappingReachable(highAddress, 1, 0x1000, 1) {
+		t.Fatal("accepted high/low mapping through signed wraparound")
+	}
+}
+
+func TestBuildPatchRelocatesInternalX5DirectCall(t *testing.T) {
+	const (
+		targetAddr = uintptr(0x200000)
+		proxyAddr  = uintptr(0x400000)
+		hookAddr   = uintptr(0x600000)
+	)
+	code := nopCode(24)
+	copy(code[16:], jal(int(riscv64asm.X5), -8))
+
+	patchSize := PatchSize(targetAddr, code, true)
+	proxy, targetPatch := BuildPatch(targetAddr, proxyAddr, hookAddr, code[:patchSize])
+	plan, ok := makePatchPlan(code[:patchSize])
+	if !ok {
+		t.Fatal("internal X5-call gateway plan failed")
+	}
+	gateway := plan.gateways[int(riscv64asm.X5)]
+	landingTarget, landing := decodedJumpTarget(t, targetPatch[20:], targetAddr+20)
+	if landing.Len != 4 || landingTarget != targetAddr+uintptr(gateway.start) {
+		t.Fatalf("X5 landing: got %v to %#x", landing, landingTarget)
+	}
+
+	veneerAddr, _ := decodedJumpTarget(t, proxy[16:], proxyAddr+16)
+	veneerOffset := int(veneerAddr - proxyAddr)
+	if got, want := binary.LittleEndian.Uint64(proxy[veneerOffset+24:]), uint64(targetAddr+20); got != want {
+		t.Fatalf("X5 return PC: got %#x, want %#x", got, want)
+	}
+	if got, want := binary.LittleEndian.Uint64(proxy[veneerOffset+32:]), uint64(proxyAddr+8); got != want {
+		t.Fatalf("X5 internal callee: got %#x, want %#x", got, want)
+	}
+}
+
+func TestPatchSizeAccountsForAUIPCVeneerCapacity(t *testing.T) {
+	codeSize := MaxPatchSize() - riscv64TailSize - riscv64HookSize
+	code := chainedForwardPrefix(codeSize)
+	copy(code[16:], auipc(10, 1))
+
+	assertPanicContains(t, "proxy requires", func() {
+		PatchSize(0x200000, code, true)
+	})
+}
+
+func TestBuildProxyChecksEachCompressedVeneerOffset(t *testing.T) {
+	code := nopCode(1904)
+	for pos := 0; pos < 81*4; pos += 4 {
+		copy(code[pos:], auipc(10, 1))
+	}
+	copy(code[1800:], cJ(2046))
+	copy(code[1802:], []byte{0x01, 0x00})
+
+	assertPanicContains(t, "cannot reach its veneer", func() {
+		BuildProxy(0x200000, 0x400000, code)
+	})
+}
+
+func TestBuildProxyRelocatesAUIPCPastBypassedTailJump(t *testing.T) {
+	const (
+		targetAddr = uintptr(0x200000)
+		proxyAddr  = uintptr(0x400000)
+	)
+	code := nopCode(24)
+	copy(code[0:], beqOffset(8))
+	copy(code[4:], jalr(riscv64Zero, 10, 0))
+	copy(code[8:], auipc(11, 1))
+
+	proxy := BuildProxy(targetAddr, proxyAddr, code)
+	veneerAddr, source := decodedJumpTarget(t, proxy[8:], proxyAddr+8)
+	if source.Len != 4 || source.Args[0].(riscv64asm.Reg) != riscv64asm.X0 {
+		t.Fatalf("reachable AUIPC source: got %v, want JAL X0", source)
+	}
+	veneerOffset := int(veneerAddr - proxyAddr)
+	if got, want := binary.LittleEndian.Uint64(proxy[veneerOffset+16:]), uint64(targetAddr+8+1<<12); got != want {
+		t.Fatalf("reachable AUIPC value: got %#x, want %#x", got, want)
+	}
+}
+
+func TestBuildPatchPlansCallPastBypassedTailJump(t *testing.T) {
+	const (
+		targetAddr = uintptr(0x200000)
+		proxyAddr  = uintptr(0x400000)
+		hookAddr   = uintptr(0x600000)
+	)
+	code := nopCode(24)
+	copy(code[0:], beqOffset(8))
+	copy(code[4:], jalr(riscv64Zero, 10, 0))
+	copy(code[8:], jal(riscv64RA, 0x400))
+
+	patchSize := PatchSize(targetAddr, code, true)
+	proxy, targetPatch := BuildPatch(targetAddr, proxyAddr, hookAddr, code[:patchSize])
+	plan, ok := makePatchPlan(code[:patchSize])
+	if !ok || len(plan.landings) != 1 || plan.landings[0].start != 12 {
+		t.Fatalf("reachable call plan: got %+v, ok=%v", plan.landings, ok)
+	}
+	gateway := plan.gateways[riscv64RA]
+	landingTarget, landing := decodedJumpTarget(t, targetPatch[12:], targetAddr+12)
+	if landing.Len != 4 || landingTarget != targetAddr+uintptr(gateway.start) {
+		t.Fatalf("reachable call landing: got %v to %#x", landing, landingTarget)
+	}
+
+	veneerAddr, _ := decodedJumpTarget(t, proxy[8:], proxyAddr+8)
+	veneerOffset := int(veneerAddr - proxyAddr)
+	if got, want := binary.LittleEndian.Uint64(proxy[veneerOffset+24:]), uint64(targetAddr+12); got != want {
+		t.Fatalf("reachable call return PC: got %#x, want %#x", got, want)
+	}
+	if got, want := binary.LittleEndian.Uint64(proxy[veneerOffset+32:]), uint64(targetAddr+8+0x400); got != want {
+		t.Fatalf("reachable call target: got %#x, want %#x", got, want)
+	}
+}
+
+func TestProxyStopsAtUnbypassedTailJump(t *testing.T) {
+	const (
+		targetAddr = uintptr(0x200000)
+		proxyAddr  = uintptr(0x400000)
+	)
+	code := nopCode(24)
+	copy(code[4:], jalr(riscv64Zero, 10, 0))
+	for index := 8; index < len(code); index++ {
+		code[index] = 0xff
+	}
+
+	if got := PatchSize(targetAddr, code, true); got != len(code) {
+		t.Fatalf("tail-jump patch size: got %d, want %d", got, len(code))
+	}
+	proxy := BuildProxy(targetAddr, proxyAddr, code)
+	if !bytes.Equal(proxy[8:len(code)], code[8:]) {
+		t.Fatalf("unreachable bytes after tail jump were modified: got %x, want %x",
+			proxy[8:len(code)], code[8:])
+	}
+}
+
+func TestBuildProxyRelocatesAUIPCPastDirectJump(t *testing.T) {
+	const (
+		targetAddr = uintptr(0x200000)
+		proxyAddr  = uintptr(0x400000)
+	)
+	code := nopCode(24)
+	copy(code[0:], jal(riscv64Zero, 8))
+	copy(code[4:], jalr(riscv64Zero, 10, 0))
+	copy(code[8:], auipc(11, 1))
+
+	proxy := BuildProxy(targetAddr, proxyAddr, code)
+	veneerAddr, source := decodedJumpTarget(t, proxy[8:], proxyAddr+8)
+	if source.Len != 4 || source.Args[0].(riscv64asm.Reg) != riscv64asm.X0 {
+		t.Fatalf("direct-jump AUIPC source: got %v, want JAL X0", source)
+	}
+	veneerOffset := int(veneerAddr - proxyAddr)
+	if got, want := binary.LittleEndian.Uint64(proxy[veneerOffset+16:]), uint64(targetAddr+8+1<<12); got != want {
+		t.Fatalf("direct-jump AUIPC value: got %#x, want %#x", got, want)
+	}
+}
+
+func TestBuildPatchScansInternalCallTargetPastTail(t *testing.T) {
+	const (
+		targetAddr = uintptr(0x200000)
+		proxyAddr  = uintptr(0x400000)
+		hookAddr   = uintptr(0x600000)
+	)
+	code := nopCode(24)
+	copy(code[4:], jal(riscv64RA, 8))
+	copy(code[8:], jalr(riscv64Zero, 10, 0))
+	copy(code[12:], auipc(11, 1))
+
+	patchSize := PatchSize(targetAddr, code, true)
+	proxy, targetPatch := BuildPatch(targetAddr, proxyAddr, hookAddr, code[:patchSize])
+	plan, ok := makePatchPlan(code[:patchSize])
+	if !ok || len(plan.landings) != 1 || plan.landings[0].start != 8 {
+		t.Fatalf("internal-call plan: got %+v, ok=%v", plan.landings, ok)
+	}
+	gateway := plan.gateways[riscv64RA]
+	landingTarget, landing := decodedJumpTarget(t, targetPatch[8:], targetAddr+8)
+	if landing.Len != 4 || landingTarget != targetAddr+uintptr(gateway.start) {
+		t.Fatalf("internal-call landing: got %v to %#x", landing, landingTarget)
+	}
+
+	callVeneerAddr, _ := decodedJumpTarget(t, proxy[4:], proxyAddr+4)
+	callVeneerOffset := int(callVeneerAddr - proxyAddr)
+	if got, want := binary.LittleEndian.Uint64(proxy[callVeneerOffset+32:]), uint64(proxyAddr+12); got != want {
+		t.Fatalf("internal callee target: got %#x, want %#x", got, want)
+	}
+	auipcVeneerAddr, _ := decodedJumpTarget(t, proxy[12:], proxyAddr+12)
+	auipcVeneerOffset := int(auipcVeneerAddr - proxyAddr)
+	if got, want := binary.LittleEndian.Uint64(proxy[auipcVeneerOffset+16:]), uint64(targetAddr+12+1<<12); got != want {
+		t.Fatalf("internal callee AUIPC value: got %#x, want %#x", got, want)
+	}
+}
+
+func TestDirectJumpSkipsUnreachableGap(t *testing.T) {
+	const (
+		targetAddr = uintptr(0x200000)
+		proxyAddr  = uintptr(0x400000)
+	)
+	code := nopCode(24)
+	copy(code[0:], jal(riscv64Zero, 16))
+	for index := 4; index < 16; index++ {
+		code[index] = 0xff
+	}
+	copy(code[16:], auipc(11, 1))
+
+	if got := PatchSize(targetAddr, code, true); got != len(code) {
+		t.Fatalf("direct-jump patch size: got %d, want %d", got, len(code))
+	}
+	proxy := BuildProxy(targetAddr, proxyAddr, code)
+	veneerAddr, _ := decodedJumpTarget(t, proxy[16:], proxyAddr+16)
+	veneerOffset := int(veneerAddr - proxyAddr)
+	if got, want := binary.LittleEndian.Uint64(proxy[veneerOffset+16:]), uint64(targetAddr+16+1<<12); got != want {
+		t.Fatalf("post-gap AUIPC value: got %#x, want %#x", got, want)
+	}
+	if !bytes.Equal(proxy[4:16], code[4:16]) {
+		t.Fatalf("unreachable direct-jump gap was modified: got %x, want %x", proxy[4:16], code[4:16])
+	}
+}
+
+func TestProxyStopsAtReturnWithoutBypass(t *testing.T) {
+	const (
+		targetAddr = uintptr(0x200000)
+		proxyAddr  = uintptr(0x400000)
+	)
+	code := nopCode(24)
+	copy(code[4:], jalr(riscv64Zero, riscv64RA, 0))
+	for index := 8; index < len(code); index++ {
+		code[index] = 0xff
+	}
+
+	if got := PatchSize(targetAddr, code, false); got != len(code) {
+		t.Fatalf("return patch size: got %d, want %d", got, len(code))
+	}
+	proxy := BuildProxy(targetAddr, proxyAddr, code)
+	if !bytes.Equal(proxy[8:len(code)], code[8:]) {
+		t.Fatalf("bytes after return were modified: got %x, want %x",
+			proxy[8:len(code)], code[8:])
+	}
+}
+
+func TestBuildProxyRelocatesAUIPCPastBypassedReturn(t *testing.T) {
+	const (
+		targetAddr = uintptr(0x200000)
+		proxyAddr  = uintptr(0x400000)
+	)
+	code := nopCode(24)
+	copy(code[0:], beqOffset(8))
+	copy(code[4:], jalr(riscv64Zero, riscv64RA, 0))
+	copy(code[8:], auipc(11, 1))
+
+	if got := PatchSize(targetAddr, code, true); got != len(code) {
+		t.Fatalf("bypassed-return patch size: got %d, want %d", got, len(code))
+	}
+	proxy := BuildProxy(targetAddr, proxyAddr, code)
+	veneerAddr, source := decodedJumpTarget(t, proxy[8:], proxyAddr+8)
+	if source.Len != 4 || source.Args[0].(riscv64asm.Reg) != riscv64asm.X0 {
+		t.Fatalf("reachable AUIPC source: got %v, want JAL X0", source)
+	}
+	veneerOffset := int(veneerAddr - proxyAddr)
+	if got, want := binary.LittleEndian.Uint64(proxy[veneerOffset+16:]), uint64(targetAddr+8+1<<12); got != want {
+		t.Fatalf("reachable AUIPC value: got %#x, want %#x", got, want)
+	}
+}
+
+func TestBuildPatchScansInternalCallTargetPastReturn(t *testing.T) {
+	const (
+		targetAddr = uintptr(0x200000)
+		proxyAddr  = uintptr(0x400000)
+		hookAddr   = uintptr(0x600000)
+	)
+	code := nopCode(24)
+	copy(code[8:], jal(riscv64RA, 8))
+	copy(code[12:], jalr(riscv64Zero, riscv64RA, 0))
+	copy(code[16:], auipc(11, 1))
+
+	patchSize := PatchSize(targetAddr, code, true)
+	proxy, _ := BuildPatch(targetAddr, proxyAddr, hookAddr, code[:patchSize])
+	callVeneerAddr, _ := decodedJumpTarget(t, proxy[8:], proxyAddr+8)
+	callVeneerOffset := int(callVeneerAddr - proxyAddr)
+	if got, want := binary.LittleEndian.Uint64(proxy[callVeneerOffset+32:]), uint64(proxyAddr+16); got != want {
+		t.Fatalf("internal callee target: got %#x, want %#x", got, want)
+	}
+	auipcVeneerAddr, _ := decodedJumpTarget(t, proxy[16:], proxyAddr+16)
+	auipcVeneerOffset := int(auipcVeneerAddr - proxyAddr)
+	if got, want := binary.LittleEndian.Uint64(proxy[auipcVeneerOffset+16:]), uint64(targetAddr+16+1<<12); got != want {
+		t.Fatalf("internal callee AUIPC value: got %#x, want %#x", got, want)
+	}
+}
+
+func TestBuildProxyRelocatesBackwardReachableGap(t *testing.T) {
+	const (
+		targetAddr = uintptr(0x200000)
+		proxyAddr  = uintptr(0x400000)
+	)
+	code := nopCode(24)
+	copy(code[0:], jal(riscv64Zero, 16))
+	copy(code[4:], auipc(11, 1))
+	copy(code[16:], beqOffset(-12))
+
+	if got := PatchSize(targetAddr, code, true); got != len(code) {
+		t.Fatalf("backward-reachable patch size: got %d, want %d", got, len(code))
+	}
+	proxy := BuildProxy(targetAddr, proxyAddr, code)
+	veneerAddr, source := decodedJumpTarget(t, proxy[4:], proxyAddr+4)
+	if source.Len != 4 || source.Args[0].(riscv64asm.Reg) != riscv64asm.X0 {
+		t.Fatalf("backward-reachable AUIPC source: got %v, want JAL X0", source)
+	}
+	veneerOffset := int(veneerAddr - proxyAddr)
+	if got, want := binary.LittleEndian.Uint64(proxy[veneerOffset+16:]), uint64(targetAddr+4+1<<12); got != want {
+		t.Fatalf("backward-reachable AUIPC value: got %#x, want %#x", got, want)
+	}
+}
+
+func TestCollectReturnLandingsSortsWorklistBlocks(t *testing.T) {
+	code := nopCode(28)
+	copy(code[0:], jal(riscv64Zero, 16))
+	copy(code[4:], jal(riscv64RA, 64))
+	copy(code[8:], jal(riscv64Zero, 16))
+	copy(code[16:], jal(riscv64RA, 64))
+	copy(code[20:], beqOffset(-16))
+	copy(code[24:], jalr(riscv64Zero, riscv64RA, 0))
+
+	landings := collectReturnLandings(code)
+	if len(landings) != 2 {
+		t.Fatalf("return landing count: got %d, want 2", len(landings))
+	}
+	for index, want := range []int{8, 20} {
+		if got := landings[index].start; got != want {
+			t.Fatalf("return landing %d: got +%d, want +%d", index, got, want)
+		}
+	}
+}
+
+func TestDisassembleBranchToCutoffBypassesReturn(t *testing.T) {
+	code := nopCode(32)
+	copy(code[0:], beqOffset(32))
+	copy(code[4:], jalr(riscv64Zero, riscv64RA, 0))
+
+	if got := Disassemble(code, 8, true); got != len(code) {
+		t.Fatalf("branch-to-cutoff cutting point: got %d, want %d", got, len(code))
+	}
+}
+
+func TestDisassembleTailJumpMayLandAtCutoff(t *testing.T) {
+	code := nopCode(24)
+	copy(code[0:], jal(riscv64Zero, 24))
+
+	if got := Disassemble(code, len(code), true); got != len(code) {
+		t.Fatalf("tail-jump cutting point: got %d, want %d", got, len(code))
+	}
+}
+
+func TestDisassembleCallToCutoffDoesNotHideShortFunction(t *testing.T) {
+	code := nopCode(24)
+	copy(code[0:], jal(riscv64RA, 24))
+	copy(code[4:], jalr(riscv64Zero, riscv64RA, 0))
+
+	assertPanicContains(t, "function is too short to patch", func() {
+		Disassemble(code, len(code), true)
+	})
+}

--- a/internal/monkey/inst/proxy_riscv64.go
+++ b/internal/monkey/inst/proxy_riscv64.go
@@ -1,0 +1,953 @@
+//go:build linux && riscv64
+// +build linux,riscv64
+
+/*
+ * Copyright 2022 ByteDance Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package inst
+
+import (
+	"sort"
+	"syscall"
+
+	"github.com/bytedance/mockey/internal/monkey/common"
+	"github.com/bytedance/mockey/internal/tool"
+	"golang.org/x/arch/riscv64/riscv64asm"
+)
+
+const (
+	riscv64EntryPatchSize  = 8
+	riscv64InitialCopySize = 24
+	riscv64GatewaySize     = 8
+	riscv64TailSize        = 24
+	riscv64HookSize        = 24
+	riscv64AUIPCVeneerSize = 24
+	riscv64JumpVeneerSize  = 24
+	riscv64CallVeneerSize  = 40
+	riscv64IndirectSize    = 12
+	riscv64SameRegSize     = 16
+	riscv64DispatcherSize  = 24
+
+	mmapFixedNoReplace = 0x100000
+	proxySearchStep    = uintptr(64 << 20)
+)
+
+var (
+	runtimeMorestackAddr       uintptr
+	runtimeMorestackNoctxtAddr uintptr
+)
+
+func MaxPatchSize() int {
+	return common.PageSize()
+}
+
+// AllocateProxy reserves an executable-proxy page within AUIPC/JALR range of
+// the target. Keeping the page close lets static target PCs serve as safe
+// stack-map landing points while execution resumes in the proxy.
+func AllocateProxy(targetAddr uintptr) []byte {
+	pageSize := uintptr(common.PageSize())
+	targetPage := targetAddr &^ (pageSize - 1)
+
+	// A non-fixed hint works on kernels that honor nearby mmap hints.
+	for distance := proxySearchStep; distance < 1<<31; distance += proxySearchStep {
+		for _, hint := range proxyCandidates(targetPage, distance, pageSize) {
+			if page, ok := mmapProxyPage(hint, pageSize, false, targetAddr); ok {
+				return page
+			}
+		}
+	}
+
+	// MAP_FIXED_NOREPLACE guarantees proximity without replacing an existing
+	// mapping. Search at base-page granularity so many concurrent patches near
+	// the same text mapping do not exhaust a sparse set of hints. Older kernels
+	// may reject or ignore the flag; returned addresses are range-checked.
+	for distance := pageSize; distance < 1<<31; distance += pageSize {
+		for _, hint := range proxyCandidates(targetPage, distance, pageSize) {
+			if page, ok := mmapProxyPage(hint, pageSize, true, targetAddr); ok {
+				return page
+			}
+		}
+	}
+
+	tool.Assert(false, "cannot allocate a RISC-V proxy page within AUIPC/JALR range of %#x", targetAddr)
+	return nil
+}
+
+func ReleaseProxy(proxy []byte) {
+	_, _, errno := syscall.RawSyscall(
+		syscall.SYS_MUNMAP,
+		common.PtrOf(proxy),
+		uintptr(len(proxy)),
+		0,
+	)
+	tool.Assert(errno == 0, "free proxy page failed: %v", errno)
+}
+
+func proxyCandidates(base, distance, pageSize uintptr) []uintptr {
+	candidates := make([]uintptr, 0, 2)
+	if base <= ^uintptr(0)-distance {
+		candidates = append(candidates, (base+distance)&^(pageSize-1))
+	}
+	if base > distance {
+		candidates = append(candidates, (base-distance)&^(pageSize-1))
+	}
+	return candidates
+}
+
+func addressRangeEnd(start, size uintptr) (uintptr, bool) {
+	if size == 0 || start > ^uintptr(0)-(size-1) {
+		return 0, false
+	}
+	return start + size - 1, true
+}
+
+func proxyMappingReachable(targetAddr, targetSize, proxyAddr, proxySize uintptr) bool {
+	targetEnd, targetOK := addressRangeEnd(targetAddr, targetSize)
+	proxyEnd, proxyOK := addressRangeEnd(proxyAddr, proxySize)
+	if !targetOK || !proxyOK {
+		return false
+	}
+	for _, from := range []uintptr{targetAddr, targetEnd} {
+		for _, to := range []uintptr{proxyAddr, proxyEnd} {
+			_, _, forward := pcRelativeParts(from, to)
+			_, _, reverse := pcRelativeParts(to, from)
+			if !forward || !reverse {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+func mmapProxyPage(hint, size uintptr, fixed bool, targetAddr uintptr) ([]byte, bool) {
+	flags := uintptr(syscall.MAP_ANON | syscall.MAP_PRIVATE)
+	if fixed {
+		flags |= mmapFixedNoReplace
+	}
+	addr, _, errno := syscall.RawSyscall6(
+		syscall.SYS_MMAP,
+		hint,
+		size,
+		uintptr(syscall.PROT_READ|syscall.PROT_WRITE),
+		flags,
+		^uintptr(0),
+		0,
+	)
+	if errno != 0 {
+		return nil, false
+	}
+	if !proxyMappingReachable(targetAddr, uintptr(MaxPatchSize()), addr, size) {
+		_, _, _ = syscall.RawSyscall(syscall.SYS_MUNMAP, addr, size, 0)
+		return nil, false
+	}
+	return common.BytesOf(addr, int(size)), true
+}
+
+// PatchSize returns enough whole original instructions for the entry jump,
+// every static return landing, and the target-side gateways used by calls in
+// the copied prefix.
+func PatchSize(targetAddr uintptr, code []byte, checkLen bool) int {
+	cuttingIdx := Disassemble(code, riscv64InitialCopySize, checkLen)
+	tool.Assert(
+		cuttingIdx >= riscv64InitialCopySize,
+		"RISC-V patch scan did not reach the initial prefix at %#x: got %d, need %d",
+		targetAddr,
+		cuttingIdx,
+		riscv64InitialCopySize,
+	)
+	for {
+		required := cuttingIdx
+		if boundary := extendTMPSequence(code, cuttingIdx); boundary > required {
+			required = boundary
+		}
+		landings := collectReturnLandings(code[:cuttingIdx])
+		assertCompressedGatewayLayout(landings)
+		for _, landing := range landings {
+			if landing.end > required {
+				required = landing.end
+			}
+		}
+		if required <= cuttingIdx {
+			assertProxyLayout(code[:cuttingIdx], true)
+			if _, ok := makePatchPlan(code[:cuttingIdx]); ok {
+				return cuttingIdx
+			}
+			required = cuttingIdx + riscv64GatewaySize
+		}
+		tool.Assert(
+			required <= len(code) && required <= MaxPatchSize(),
+			"RISC-V patch prefix is too large at %#x: need at least %d bytes",
+			targetAddr,
+			required,
+		)
+		nextCuttingIdx := Disassemble(code, required, checkLen)
+		tool.Assert(
+			nextCuttingIdx >= required && nextCuttingIdx > cuttingIdx,
+			"RISC-V patch scan made no progress at %#x: %d -> %d (need %d)",
+			targetAddr,
+			cuttingIdx,
+			nextCuttingIdx,
+			required,
+		)
+		cuttingIdx = nextCuttingIdx
+		tool.Assert(
+			cuttingIdx <= MaxPatchSize(),
+			"RISC-V patch prefix is too large at %#x: %d",
+			targetAddr,
+			cuttingIdx,
+		)
+	}
+}
+
+// BuildPatch creates both the relocated origin proxy and the bytes installed
+// at the real target. Return landings preserve the static target PC in X1/X5
+// and use target-side gateways to resume at the matching proxy offset.
+func BuildPatch(targetAddr, proxyAddr, hookAddr uintptr, code []byte) (proxy, targetPatch []byte) {
+	assertProxyLayout(code, true)
+	assertCompressedGatewayLayout(collectReturnLandings(code))
+	plan, ok := makePatchPlan(code)
+	tool.Assert(ok, "cannot place RISC-V return gateways in a %d-byte patch", len(code))
+
+	targetPatch = append([]byte(nil), code...)
+	proxy = buildProxy(targetAddr, proxyAddr, code, targetPatch)
+
+	for _, linkReg := range plan.linkRegisters() {
+		proxy = alignVeneer(proxy)
+		dispatcherOffset := len(proxy)
+		proxy = appendReturnDispatcher(proxy, linkReg, proxyAddr-targetAddr)
+		gateway := plan.gateways[linkReg]
+		copy(
+			targetPatch[gateway.start:gateway.end],
+			pcRelativeJump(
+				targetAddr+uintptr(gateway.start),
+				proxyAddr+uintptr(dispatcherOffset),
+			),
+		)
+	}
+	for _, landing := range plan.landings {
+		gateway := plan.gateways[landing.linkReg]
+		copy(
+			targetPatch[landing.start:landing.end],
+			shortJump(
+				landing.size(),
+				targetAddr+uintptr(landing.start),
+				targetAddr+uintptr(gateway.start),
+			),
+		)
+	}
+
+	proxy = alignVeneer(proxy)
+	hookOffset := len(proxy)
+	proxy = appendHookTrampoline(proxy, hookAddr)
+	assertProxyCapacity(len(proxy))
+	copy(
+		targetPatch[:riscv64EntryPatchSize],
+		pcRelativeJump(targetAddr, proxyAddr+uintptr(hookOffset)),
+	)
+	return proxy, targetPatch
+}
+
+// BuildProxy is kept as the relocation-only entry point used by focused unit
+// tests. External calls require BuildPatch because they also need a static
+// return landing in the target.
+func BuildProxy(targetAddr, proxyAddr uintptr, code []byte) []byte {
+	return buildProxy(targetAddr, proxyAddr, code, nil)
+}
+
+// RISC-V PC-relative instructions cannot be copied to an mmap'ed proxy
+// verbatim because the proxy is generally far from .text.
+func buildProxy(targetAddr, proxyAddr uintptr, code, targetPatch []byte) []byte {
+	assertProxyLayout(code, targetPatch != nil)
+	proxy := append([]byte(nil), code...)
+	proxy = alignVeneer(proxy)
+	proxy = append(proxy, BranchTo(targetAddr+uintptr(len(code)))...)
+
+	var scan reachableCodeScan
+	for pos := 0; pos < len(code); {
+		instruction, err := riscv64asm.Decode(code[pos:])
+		tool.Assert(err == nil, "decode proxy instruction at +%d: %v", pos, err)
+		scan.observe(pos, instruction, code[pos:])
+
+		switch instruction.Op {
+		case riscv64asm.AUIPC:
+			rd := instruction.Args[0].(riscv64asm.Reg)
+			if rd != riscv64asm.X0 {
+				value := relocatedAUIPCValue(code, pos, instruction, targetAddr, proxyAddr)
+				var veneerOffset int
+				proxy, veneerOffset = appendAUIPCVeneer(
+					proxy,
+					proxyAddr,
+					int(rd),
+					value,
+					proxyAddr+uintptr(pos+instruction.Len),
+				)
+				copy(
+					proxy[pos:pos+instruction.Len],
+					jal(riscv64Zero, checkedJALOffset(proxyAddr+uintptr(pos), proxyAddr+uintptr(veneerOffset))),
+				)
+			}
+		case riscv64asm.JAL:
+			jumpOffset := jalImmediate(code[pos:], instruction)
+			targetOffset := pos + int(jumpOffset)
+			rd := instruction.Args[0].(riscv64asm.Reg)
+			if rd != riscv64asm.X0 || isExternalJAL(targetOffset, len(code), rd) {
+				originalTarget := addSigned(targetAddr+uintptr(pos), int64(jumpOffset))
+				internalTarget := targetOffset >= 0 && targetOffset < len(code)
+				calleeTarget := originalTarget
+				if internalTarget {
+					calleeTarget = proxyAddr + uintptr(targetOffset)
+				}
+				proxy = alignVeneer(proxy)
+				veneerOffset := len(proxy)
+				switch rd {
+				case riscv64asm.X0:
+					proxy = appendAbsoluteJumpVeneer(proxy, calleeTarget)
+				case riscv64asm.X1, riscv64asm.X5:
+					tool.Assert(targetPatch != nil, "call relocation requires a target return landing")
+					if rd == riscv64asm.X5 && !internalTarget {
+						tool.Assert(
+							isRuntimeMorestack(originalTarget),
+							"cannot relocate an external X5 call at +%d to %#x",
+							pos,
+							originalTarget,
+						)
+					}
+					returnPos := pos + instruction.Len
+					proxy = appendCallVeneer(
+						proxy,
+						int(rd),
+						targetAddr+uintptr(returnPos),
+						calleeTarget,
+					)
+				default:
+					tool.Assert(
+						false,
+						"cannot safely relocate a call using %v at +%d",
+						rd,
+						pos,
+					)
+				}
+				// A two-byte C.J cannot be expanded in place. shortJump rejects a
+				// veneer beyond its architectural +/-2 KiB range explicitly.
+				copy(
+					proxy[pos:pos+instruction.Len],
+					shortJump(
+						instruction.Len,
+						proxyAddr+uintptr(pos),
+						proxyAddr+uintptr(veneerOffset),
+					),
+				)
+			}
+		case riscv64asm.JALR:
+			rd := instruction.Args[0].(riscv64asm.Reg)
+			switch rd {
+			case riscv64asm.X0:
+				// Returns and indirect tail jumps keep their existing link state.
+			case riscv64asm.X1, riscv64asm.X5:
+				tool.Assert(targetPatch != nil, "indirect call relocation requires a target return landing")
+				regOffset := instruction.Args[1].(riscv64asm.RegOffset)
+				proxy = alignVeneer(proxy)
+				veneerOffset := len(proxy)
+				proxy = appendIndirectCallVeneer(
+					proxy,
+					proxyAddr,
+					int(rd),
+					int(regOffset.OfsReg),
+					int32(regOffset.Ofs.Imm),
+					targetAddr+uintptr(pos+instruction.Len),
+				)
+				copy(
+					proxy[pos:pos+instruction.Len],
+					shortJump(
+						instruction.Len,
+						proxyAddr+uintptr(pos),
+						proxyAddr+uintptr(veneerOffset),
+					),
+				)
+			default:
+				tool.Assert(false, "cannot safely relocate an indirect call using %v at +%d", rd, pos)
+			}
+		case riscv64asm.BEQ, riscv64asm.BNE, riscv64asm.BLT, riscv64asm.BGE, riscv64asm.BLTU, riscv64asm.BGEU:
+			targetOffset := pos + int(instruction.Args[2].(riscv64asm.Simm).Imm)
+			tool.Assert(
+				targetOffset >= 0 && targetOffset <= len(code),
+				"cannot relocate external conditional branch at +%d to target offset %d",
+				pos,
+				targetOffset,
+			)
+		}
+
+		nextPos, stop := scan.advance(pos, instruction, len(code))
+		if stop {
+			break
+		}
+		pos = nextPos
+	}
+	assertProxyCapacity(len(proxy))
+	return proxy
+}
+
+func alignedProxyOffset(size int) int {
+	return (size + 7) &^ 7
+}
+
+func assertProxyLayout(code []byte, patched bool) {
+	proxySize := alignedProxyOffset(len(code)) + riscv64TailSize
+	assertProxyCapacity(proxySize)
+
+	var scan reachableCodeScan
+	for pos := 0; pos < len(code); {
+		instruction, err := riscv64asm.Decode(code[pos:])
+		tool.Assert(err == nil, "decode proxy layout at +%d: %v", pos, err)
+		scan.observe(pos, instruction, code[pos:])
+
+		switch instruction.Op {
+		case riscv64asm.AUIPC:
+			if instruction.Args[0].(riscv64asm.Reg) != riscv64asm.X0 {
+				proxySize = alignedProxyOffset(proxySize) + riscv64AUIPCVeneerSize
+			}
+		case riscv64asm.JAL:
+			jumpOffset := jalImmediate(code[pos:], instruction)
+			rd := instruction.Args[0].(riscv64asm.Reg)
+			targetOffset := pos + int(jumpOffset)
+			if rd != riscv64asm.X0 || isExternalJAL(targetOffset, len(code), rd) {
+				proxySize = alignedProxyOffset(proxySize)
+				assertSourceVeneerReachable(pos, instruction.Len, proxySize)
+				switch rd {
+				case riscv64asm.X0:
+					proxySize += riscv64JumpVeneerSize
+				case riscv64asm.X1, riscv64asm.X5:
+					tool.Assert(patched, "RISC-V call relocation requires BuildPatch")
+					proxySize += riscv64CallVeneerSize
+				default:
+					tool.Assert(false, "cannot safely relocate a call using %v at +%d", rd, pos)
+				}
+			}
+		case riscv64asm.JALR:
+			rd := instruction.Args[0].(riscv64asm.Reg)
+			switch rd {
+			case riscv64asm.X0:
+			case riscv64asm.X1, riscv64asm.X5:
+				tool.Assert(patched, "RISC-V indirect call relocation requires BuildPatch")
+				proxySize = alignedProxyOffset(proxySize)
+				assertSourceVeneerReachable(pos, instruction.Len, proxySize)
+				base := instruction.Args[1].(riscv64asm.RegOffset).OfsReg
+				if rd == base {
+					proxySize += riscv64SameRegSize
+				} else {
+					proxySize += riscv64IndirectSize
+				}
+			default:
+				tool.Assert(false, "cannot safely relocate an indirect call using %v at +%d", rd, pos)
+			}
+		}
+		assertProxyCapacity(proxySize)
+
+		nextPos, stop := scan.advance(pos, instruction, len(code))
+		if stop {
+			break
+		}
+		pos = nextPos
+	}
+
+	if !patched {
+		return
+	}
+	seenLink := make(map[int]bool, 2)
+	for _, landing := range collectReturnLandings(code) {
+		seenLink[landing.linkReg] = true
+	}
+	for _, linkReg := range []int{riscv64RA, int(riscv64asm.X5)} {
+		if !seenLink[linkReg] {
+			continue
+		}
+		proxySize = alignedProxyOffset(proxySize) + riscv64DispatcherSize
+		assertProxyCapacity(proxySize)
+	}
+	proxySize = alignedProxyOffset(proxySize) + riscv64HookSize
+	assertProxyCapacity(proxySize)
+}
+
+func assertSourceVeneerReachable(sourceOffset, instructionSize, veneerOffset int) {
+	difference := veneerOffset - sourceOffset
+	switch instructionSize {
+	case 2:
+		tool.Assert(
+			difference >= -2048 && difference < 2048 && difference%2 == 0,
+			"RISC-V compressed call/jump at +%d cannot reach its veneer at +%d (+/-2 KiB limit)",
+			sourceOffset,
+			veneerOffset,
+		)
+	case 4:
+		tool.Assert(
+			difference >= -(1<<20) && difference < 1<<20 && difference%2 == 0,
+			"RISC-V call/jump at +%d cannot reach its veneer at +%d (+/-1 MiB limit)",
+			sourceOffset,
+			veneerOffset,
+		)
+	default:
+		tool.Assert(false, "unsupported RISC-V jump size %d", instructionSize)
+	}
+}
+
+func assertProxyCapacity(required int) {
+	tool.Assert(
+		required <= MaxPatchSize(),
+		"RISC-V proxy requires %d bytes, exceeds the %d-byte proxy page",
+		required,
+		MaxPatchSize(),
+	)
+}
+
+func assertCompressedGatewayLayout(landings []returnLanding) {
+	for _, linkReg := range []int{riscv64RA, int(riscv64asm.X5)} {
+		lower := riscv64EntryPatchSize
+		upper := int(^uint(0) >> 1)
+		seen := false
+		for _, landing := range landings {
+			if landing.linkReg != linkReg || landing.size() != 2 {
+				continue
+			}
+			seen = true
+			if candidate := landing.start - 2048; candidate > lower {
+				lower = candidate
+			}
+			if candidate := landing.start + 2046; candidate < upper {
+				upper = candidate
+			}
+		}
+		tool.Assert(
+			!seen || lower <= upper,
+			"RISC-V compressed return landings for X%d have no common +/-2 KiB gateway range",
+			linkReg,
+		)
+	}
+}
+
+type codeRange struct {
+	start int
+	end   int
+}
+
+func isExternalJAL(targetOffset, copiedLen int, rd riscv64asm.Reg) bool {
+	if targetOffset < 0 || targetOffset > copiedLen {
+		return true
+	}
+	return targetOffset == copiedLen && rd != riscv64asm.X0
+}
+
+func appendHookTrampoline(proxy []byte, hookAddr uintptr) []byte {
+	proxy = append(proxy, auipc(riscv64CTXT, 0)...)
+	proxy = append(proxy, ld(riscv64CTXT, riscv64CTXT, 16)...)
+	proxy = append(proxy, ld(riscv64TMP, riscv64CTXT, 0)...)
+	proxy = append(proxy, jalr(riscv64Zero, riscv64TMP, 0)...)
+	return appendUint64(proxy, uint64(hookAddr))
+}
+
+func appendAbsoluteJumpVeneer(proxy []byte, target uintptr) []byte {
+	proxy = append(proxy, auipc(riscv64TMP, 0)...)
+	proxy = append(proxy, ld(riscv64TMP, riscv64TMP, 16)...)
+	proxy = append(proxy, jalr(riscv64Zero, riscv64TMP, 0)...)
+	proxy = append(proxy, nop()...)
+	return appendUint64(proxy, uint64(target))
+}
+
+// appendCallVeneer preserves a static target return PC in the link register.
+// runtime.morestack and ordinary callees therefore see the target function's
+// real stack maps. The target return PC contains a nearby jump back into the
+// proxy continuation.
+func appendCallVeneer(proxy []byte, linkReg int, returnAddr, target uintptr) []byte {
+	proxy = append(proxy, auipc(linkReg, 0)...)
+	proxy = append(proxy, ld(linkReg, linkReg, 24)...)
+	proxy = append(proxy, auipc(riscv64TMP, 0)...)
+	proxy = append(proxy, ld(riscv64TMP, riscv64TMP, 24)...)
+	proxy = append(proxy, jalr(riscv64Zero, riscv64TMP, 0)...)
+	proxy = append(proxy, nop()...)
+	proxy = appendUint64(proxy, uint64(returnAddr))
+	return appendUint64(proxy, uint64(target))
+}
+
+func isRuntimeMorestack(target uintptr) bool {
+	resolved := resolvePCRelativeJump(target)
+	return resolved == runtimeMorestackAddr || resolved == runtimeMorestackNoctxtAddr
+}
+
+func relocatedAUIPCValue(
+	code []byte,
+	pos int,
+	instruction riscv64asm.Inst,
+	targetAddr uintptr,
+	proxyAddr uintptr,
+) uintptr {
+	value := addSigned(targetAddr+uintptr(pos), auipcImm(instruction))
+	nextPos := pos + instruction.Len
+	if nextPos >= len(code) {
+		return value
+	}
+	next, err := riscv64asm.Decode(code[nextPos:])
+	if err != nil {
+		return value
+	}
+
+	rd := instruction.Args[0].(riscv64asm.Reg)
+	var (
+		effective uintptr
+		found     bool
+	)
+	if next.Op == riscv64asm.ADDI &&
+		next.Args[1].(riscv64asm.Reg) == rd {
+		effective = addSigned(value, int64(next.Args[2].(riscv64asm.Simm).Imm))
+		found = true
+	} else {
+		for _, arg := range next.Args {
+			regOffset, ok := arg.(riscv64asm.RegOffset)
+			if !ok || regOffset.OfsReg != rd {
+				continue
+			}
+			effective = addSigned(value, int64(regOffset.Ofs.Imm))
+			found = true
+			break
+		}
+	}
+	if !found || effective < targetAddr || effective >= targetAddr+uintptr(len(code)) {
+		return value
+	}
+	delta, ok := signedAddressDifference(targetAddr, proxyAddr)
+	tool.Assert(ok, "invalid RISC-V proxy delta: %#x -> %#x", targetAddr, proxyAddr)
+	return addSigned(value, delta)
+}
+
+func appendAUIPCVeneer(
+	proxy []byte,
+	proxyAddr uintptr,
+	rd int,
+	value uintptr,
+	returnAddr uintptr,
+) ([]byte, int) {
+	proxy = alignVeneer(proxy)
+	veneerOffset := len(proxy)
+	proxy = append(proxy, auipc(rd, 0)...)
+	proxy = append(proxy, ld(rd, rd, 16)...)
+	proxy = append(
+		proxy,
+		jal(riscv64Zero, checkedJALOffset(proxyAddr+uintptr(veneerOffset+8), returnAddr))...,
+	)
+	proxy = append(proxy, nop()...)
+	proxy = appendUint64(proxy, uint64(value))
+	return proxy, veneerOffset
+}
+
+func alignVeneer(proxy []byte) []byte {
+	for len(proxy)%8 != 0 {
+		// C.NOP keeps every possible entry in the executable proxy decodable.
+		proxy = append(proxy, 0x01, 0x00)
+	}
+	return proxy
+}
+
+func pcRelativeJump(from, to uintptr) []byte {
+	high, low, ok := pcRelativeParts(from, to)
+	tool.Assert(ok, "RISC-V AUIPC/JALR jump from %#x to %#x is out of range", from, to)
+	result := append([]byte(nil), auipc(riscv64TMP, high)...)
+	return append(result, jalr(riscv64Zero, riscv64TMP, low)...)
+}
+
+func signedAddressDifference(from, to uintptr) (int64, bool) {
+	if to >= from {
+		distance := to - from
+		if distance > uintptr(^uint64(0)>>1) {
+			return 0, false
+		}
+		return int64(distance), true
+	}
+	distance := from - to
+	if distance > uintptr(^uint64(0)>>1) {
+		return 0, false
+	}
+	return -int64(distance), true
+}
+
+func pcRelativeParts(from, to uintptr) (high, low int32, ok bool) {
+	difference, ok := signedAddressDifference(from, to)
+	if !ok || difference < -(1<<32) || difference > 1<<32 {
+		return 0, 0, false
+	}
+	high64 := (difference + 0x800) >> 12
+	low64 := difference - high64<<12
+	if high64 < -(1<<19) || high64 >= 1<<19 || low64 < -2048 || low64 > 2047 {
+		return 0, 0, false
+	}
+	return int32(high64), int32(low64), true
+}
+
+func checkedJALOffset(from, to uintptr) int32 {
+	offset, ok := signedAddressDifference(from, to)
+	tool.Assert(
+		ok && offset%2 == 0 && offset >= -(1<<20) && offset < 1<<20,
+		"RISC-V proxy jump from %#x to %#x is out of range",
+		from,
+		to,
+	)
+	return int32(offset)
+}
+
+func addSigned(base uintptr, offset int64) uintptr {
+	if offset >= 0 {
+		delta := uintptr(offset)
+		tool.Assert(base <= ^uintptr(0)-delta, "invalid RISC-V PC-relative address: %#x + %d", base, offset)
+		return base + delta
+	}
+	delta := uintptr(-(offset + 1)) + 1
+	tool.Assert(base >= delta, "invalid RISC-V PC-relative address: %#x + %d", base, offset)
+	return base - delta
+}
+
+// appendIndirectCallVeneer gives an indirect callee the real target return PC.
+// If JALR reads and writes the same register, preserve its old target first.
+func appendIndirectCallVeneer(
+	proxy []byte,
+	proxyAddr uintptr,
+	linkReg, baseReg int,
+	offset int32,
+	returnAddr uintptr,
+) []byte {
+	if linkReg == baseReg {
+		proxy = append(proxy, addi(riscv64TMP, baseReg, offset)...)
+		auipcAddr := proxyAddr + uintptr(len(proxy))
+		high, low, ok := pcRelativeParts(auipcAddr, returnAddr)
+		tool.Assert(ok, "RISC-V indirect call return PC %#x is out of range", returnAddr)
+		proxy = append(proxy, auipc(linkReg, high)...)
+		proxy = append(proxy, addi(linkReg, linkReg, low)...)
+		return append(proxy, jalr(riscv64Zero, riscv64TMP, 0)...)
+	}
+
+	auipcAddr := proxyAddr + uintptr(len(proxy))
+	high, low, ok := pcRelativeParts(auipcAddr, returnAddr)
+	tool.Assert(ok, "RISC-V indirect call return PC %#x is out of range", returnAddr)
+	proxy = append(proxy, auipc(linkReg, high)...)
+	proxy = append(proxy, addi(linkReg, linkReg, low)...)
+	return append(proxy, jalr(riscv64Zero, baseReg, offset)...)
+}
+
+// appendReturnDispatcher maps a real target return PC in linkReg to the same
+// instruction offset in the proxy without changing that link register.
+func appendReturnDispatcher(proxy []byte, linkReg int, proxyDelta uintptr) []byte {
+	proxy = append(proxy, auipc(riscv64TMP, 0)...)
+	proxy = append(proxy, ld(riscv64TMP, riscv64TMP, 16)...)
+	proxy = append(proxy, add(riscv64TMP, linkReg, riscv64TMP)...)
+	proxy = append(proxy, jalr(riscv64Zero, riscv64TMP, 0)...)
+	return appendUint64(proxy, uint64(proxyDelta))
+}
+
+type returnLanding struct {
+	codeRange
+	linkReg int
+}
+
+func (landing returnLanding) size() int {
+	return landing.end - landing.start
+}
+
+type patchPlan struct {
+	landings []returnLanding
+	gateways map[int]codeRange
+}
+
+func (plan patchPlan) linkRegisters() []int {
+	registers := make([]int, 0, len(plan.gateways))
+	for _, register := range []int{riscv64RA, int(riscv64asm.X5)} {
+		if _, ok := plan.gateways[register]; ok {
+			registers = append(registers, register)
+		}
+	}
+	return registers
+}
+
+func collectReturnLandings(code []byte) []returnLanding {
+	landings := make([]returnLanding, 0, 1)
+	var scan reachableCodeScan
+	for pos := 0; pos < len(code); {
+		instruction, err := riscv64asm.Decode(code[pos:])
+		tool.Assert(err == nil, "decode return landing at +%d: %v", pos, err)
+		scan.observe(pos, instruction, code[pos:])
+
+		rd := riscv64asm.X0
+		call := false
+		switch instruction.Op {
+		case riscv64asm.JAL:
+			rd = instruction.Args[0].(riscv64asm.Reg)
+			call = rd != riscv64asm.X0
+		case riscv64asm.JALR:
+			rd = instruction.Args[0].(riscv64asm.Reg)
+			call = rd != riscv64asm.X0
+		}
+		if call {
+			tool.Assert(
+				rd == riscv64asm.X1 || rd == riscv64asm.X5,
+				"cannot safely relocate a call using %v at +%d",
+				rd,
+				pos,
+			)
+			returnPos := pos + instruction.Len
+			landing := returnLanding{
+				codeRange: codeRange{start: returnPos, end: returnPos + 4},
+				linkReg:   int(rd),
+			}
+			tool.Assert(
+				landing.start >= riscv64EntryPatchSize,
+				"RISC-V return PC at +%d overlaps the entry patch",
+				landing.start,
+			)
+			landings = append(landings, landing)
+		}
+
+		nextPos, stop := scan.advance(pos, instruction, len(code))
+		if stop {
+			break
+		}
+		pos = nextPos
+	}
+	sort.Slice(landings, func(left, right int) bool {
+		return landings[left].start < landings[right].start
+	})
+	// A return landing normally needs a 4-byte JAL. If the next return PC is
+	// only two bytes away, use C.J for the earlier landing so adjacent mixed
+	// 2/4-byte calls do not overlap. The final landing remains four bytes.
+	for index := 0; index+1 < len(landings); index++ {
+		distance := landings[index+1].start - landings[index].start
+		tool.Assert(distance >= 2, "invalid RISC-V return landing distance %d", distance)
+		if distance < 4 {
+			landings[index].end = landings[index].start + 2
+		}
+	}
+	return landings
+}
+
+func makePatchPlan(code []byte) (patchPlan, bool) {
+	plan := patchPlan{
+		landings: collectReturnLandings(code),
+		gateways: make(map[int]codeRange, 2),
+	}
+	blocked := []codeRange{{start: 0, end: riscv64EntryPatchSize}}
+	for _, landing := range plan.landings {
+		if landing.end > len(code) {
+			return patchPlan{}, false
+		}
+		for _, current := range blocked[1:] {
+			tool.Assert(
+				landing.end <= current.start || landing.start >= current.end,
+				"overlapping RISC-V return landings [%d,%d) and [%d,%d)",
+				landing.start,
+				landing.end,
+				current.start,
+				current.end,
+			)
+		}
+		blocked = append(blocked, landing.codeRange)
+	}
+	registers := make([]int, 0, 2)
+	for _, landing := range plan.landings {
+		if _, exists := plan.gateways[landing.linkReg]; exists {
+			continue
+		}
+		plan.gateways[landing.linkReg] = codeRange{}
+		registers = append(registers, landing.linkReg)
+	}
+	for register := range plan.gateways {
+		delete(plan.gateways, register)
+	}
+	if !placeReturnGateways(code, registers, 0, blocked, &plan) {
+		return patchPlan{}, false
+	}
+	return plan, true
+}
+
+func placeReturnGateways(
+	code []byte,
+	registers []int,
+	index int,
+	blocked []codeRange,
+	plan *patchPlan,
+) bool {
+	if index == len(registers) {
+		return true
+	}
+	register := registers[index]
+	for offset := riscv64EntryPatchSize; offset+riscv64GatewaySize <= len(code); offset += 2 {
+		candidate := codeRange{start: offset, end: offset + riscv64GatewaySize}
+		if !rangeAvailable(candidate, blocked) ||
+			!gatewayReachable(candidate.start, register, plan.landings) {
+			continue
+		}
+		plan.gateways[register] = candidate
+		if placeReturnGateways(
+			code,
+			registers,
+			index+1,
+			append(blocked, candidate),
+			plan,
+		) {
+			return true
+		}
+		delete(plan.gateways, register)
+	}
+	return false
+}
+
+func rangeAvailable(candidate codeRange, blocked []codeRange) bool {
+	for _, current := range blocked {
+		if candidate.end > current.start && candidate.start < current.end {
+			return false
+		}
+	}
+	return true
+}
+
+func gatewayReachable(offset, linkReg int, landings []returnLanding) bool {
+	for _, landing := range landings {
+		if landing.linkReg != linkReg || landing.size() != 2 {
+			continue
+		}
+		difference := offset - landing.start
+		if difference < -2048 || difference >= 2048 {
+			return false
+		}
+	}
+	return true
+}
+
+func shortJump(size int, from, to uintptr) []byte {
+	switch size {
+	case 2:
+		return cJ(checkedCJOffset(from, to))
+	case 4:
+		return jal(riscv64Zero, checkedJALOffset(from, to))
+	default:
+		tool.Assert(false, "unsupported RISC-V jump size %d", size)
+		return nil
+	}
+}
+
+func checkedCJOffset(from, to uintptr) int32 {
+	offset, ok := signedAddressDifference(from, to)
+	tool.Assert(
+		ok && offset%2 == 0 && offset >= -2048 && offset < 2048,
+		"RISC-V compressed jump from %#x to %#x is out of range",
+		from,
+		to,
+	)
+	return int32(offset)
+}

--- a/internal/monkey/inst/proxy_runtime_riscv64.s
+++ b/internal/monkey/inst/proxy_runtime_riscv64.s
@@ -1,0 +1,26 @@
+//go:build riscv64
+// +build riscv64
+
+/*
+ * Copyright 2022 ByteDance Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "textflag.h"
+
+DATA ·runtimeMorestackAddr+0(SB)/8, $runtime·morestack(SB)
+GLOBL ·runtimeMorestackAddr(SB), RODATA|NOPTR, $8
+
+DATA ·runtimeMorestackNoctxtAddr+0(SB)/8, $runtime·morestack_noctxt(SB)
+GLOBL ·runtimeMorestackNoctxtAddr(SB), RODATA|NOPTR, $8

--- a/internal/monkey/linkname/linkname.go
+++ b/internal/monkey/linkname/linkname.go
@@ -22,7 +22,6 @@
 package linkname
 
 import (
-	"reflect"
 	"runtime"
 	"unsafe"
 )
@@ -45,12 +44,7 @@ func init() {
 	textStart := *(*uintptr)(unsafe.Pointer(uintptr(md) + uintptr(textOffset)))
 	funcTabStart := *(**functab)(unsafe.Pointer(uintptr(md) + uintptr(funcTabOffset)))
 	funcTabSize := *(*int)(unsafe.Pointer(uintptr(md) + uintptr(funcTabOffset) + unsafe.Sizeof(uintptr(0))))
-	header := reflect.SliceHeader{
-		Data: uintptr(unsafe.Pointer(funcTabStart)),
-		Len:  funcTabSize,
-		Cap:  funcTabSize,
-	}
-	funcTabs := *(*[]functab)(unsafe.Pointer(&header))
+	funcTabs := unsafe.Slice(funcTabStart, funcTabSize)
 	for _, tab := range funcTabs {
 		pc := textStart + uintptr(tab.entryoff)
 		fun := runtime.FuncForPC(pc)
@@ -66,7 +60,7 @@ const (
 
 type functab struct {
 	entryoff uint32
-	funcoff  uint32
+	_        uint32 // funcoff
 }
 
 func getMainModuleData() unsafe.Pointer {

--- a/internal/monkey/mem/write.go
+++ b/internal/monkey/mem/write.go
@@ -17,6 +17,7 @@
 package mem
 
 import (
+	"fmt"
 	"runtime"
 
 	"github.com/bytedance/mockey/internal/monkey/common"
@@ -25,12 +26,80 @@ import (
 	"github.com/bytedance/mockey/internal/tool"
 )
 
+// ReplaceState describes the state of the target after ReplaceWithSTW returns.
+type ReplaceState uint8
+
+const (
+	// ReplaceApplied means the replacement was installed successfully.
+	ReplaceApplied ReplaceState = iota
+	// ReplaceRestored means installing the replacement failed, but the original
+	// bytes were restored before the world was resumed.
+	ReplaceRestored
+	// ReplaceUncertain means both the installation and its rollback failed. The
+	// caller must assume that the target can still reference the replacement.
+	ReplaceUncertain
+)
+
+type writeFunc func(target uintptr, data []byte) error
+
+type replaceError struct {
+	apply    error
+	rollback error
+}
+
+func (e *replaceError) Error() string {
+	if e.rollback == nil {
+		return fmt.Sprintf("replace target: %v (original bytes restored)", e.apply)
+	}
+	return fmt.Sprintf("replace target: %v; rollback target: %v", e.apply, e.rollback)
+}
+
+func (e *replaceError) Unwrap() error {
+	return e.apply
+}
+
 // WriteWithSTW copies data bytes to the target address and replaces the original bytes, during which it will stop the
 // world (only the current goroutine's P is running).
 func WriteWithSTW(target uintptr, data []byte) {
 	resumeFn := suspendRuntime()
 	defer resumeFn()
 
+	err := writeRange(target, data, Write)
+	tool.Assert(err == nil, err)
+}
+
+// ReplaceWithSTW installs replacement at target. If installation fails, it
+// restores original before resuming the world. A ReplaceUncertain result means
+// that the caller must keep every object referenced by replacement alive.
+// A writer panic is propagated after the runtime resumes; the caller must then
+// treat the target as uncertain because the writer can already have modified it.
+func ReplaceWithSTW(target uintptr, replacement, original []byte) (ReplaceState, error) {
+	resumeFn := suspendRuntime()
+	defer resumeFn()
+
+	return replaceWithWriter(target, replacement, original, Write)
+}
+
+func replaceWithWriter(target uintptr, replacement, original []byte, writer writeFunc) (ReplaceState, error) {
+	if len(replacement) != len(original) {
+		return ReplaceRestored, fmt.Errorf(
+			"replacement and original lengths differ: %d != %d",
+			len(replacement), len(original),
+		)
+	}
+	applyErr := writeRange(target, replacement, writer)
+	if applyErr == nil {
+		return ReplaceApplied, nil
+	}
+
+	rollbackErr := writeRange(target, original, writer)
+	if rollbackErr == nil {
+		return ReplaceRestored, &replaceError{apply: applyErr}
+	}
+	return ReplaceUncertain, &replaceError{apply: applyErr, rollback: rollbackErr}
+}
+
+func writeRange(target uintptr, data []byte, writer writeFunc) error {
 	begin := target
 	end := target + uintptr(len(data))
 	for begin < end {
@@ -38,15 +107,18 @@ func WriteWithSTW(target uintptr, data []byte) {
 			nextPage := common.PageOf(begin) + uintptr(common.PageSize())
 			buf := data[:nextPage-begin]
 			data = data[nextPage-begin:]
-			err := Write(begin, buf)
-			tool.Assert(err == nil, err)
+			if err := writer(begin, buf); err != nil {
+				return fmt.Errorf("write %#x: %w", begin, err)
+			}
 			begin += uintptr(len(buf))
 			continue
 		}
-		err := Write(begin, data)
-		tool.Assert(err == nil, err)
-		break
+		if err := writer(begin, data); err != nil {
+			return fmt.Errorf("write %#x: %w", begin, err)
+		}
+		return nil
 	}
+	return nil
 }
 
 func suspendRuntime() (resume func()) {

--- a/internal/monkey/mem/write_linux.go
+++ b/internal/monkey/mem/write_linux.go
@@ -19,6 +19,7 @@ package mem
 import (
 	"fmt"
 	"reflect"
+	"runtime"
 	"syscall"
 
 	"github.com/bytedance/mockey/internal/monkey/common"
@@ -29,7 +30,17 @@ func Write(target uintptr, data []byte) error {
 	targetPage := common.PageOf(target)
 	fnPage := common.PageOf(reflect.ValueOf(write).Pointer())
 	tool.DebugPrintf("Write: target page(0x%x), fn page(0x%x), len(%v)\n", targetPage, fnPage, len(data))
-	res := write(target, common.PtrOf(data), len(data), targetPage, common.PageSize(), syscall.PROT_READ|syscall.PROT_EXEC)
+
+	dataPointer := common.PtrOf(data)
+	res := write(
+		target,
+		dataPointer,
+		len(data),
+		targetPage,
+		common.PageSize(),
+		syscall.PROT_READ|syscall.PROT_EXEC,
+	)
+	runtime.KeepAlive(data)
 	if res != 0 {
 		return fmt.Errorf("write failed, code %v", res)
 	}

--- a/internal/monkey/mem/write_linux_riscv64.s
+++ b/internal/monkey/mem/write_linux_riscv64.s
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2022 ByteDance Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "textflag.h"
+
+#define NOP4 WORD $0x00000013;
+#define NOP16 NOP4; NOP4; NOP4; NOP4;
+#define NOP64 NOP16; NOP16; NOP16; NOP16;
+#define NOP512 NOP64; NOP64; NOP64; NOP64; NOP64; NOP64; NOP64; NOP64;
+#define NOP4096 NOP512; NOP512; NOP512; NOP512; NOP512; NOP512; NOP512; NOP512;
+#define NOP16384 NOP4096; NOP4096; NOP4096; NOP4096;
+#define NOP65536 NOP16384; NOP16384; NOP16384; NOP16384;
+
+#define protRW $(0x1|0x2)
+#define protRX $(0x1|0x4)
+#define mProtect $226
+#define flushICache $259
+
+TEXT ·write(SB),NOSPLIT|NOFRAME,$0-56
+// Keep the executable critical section at least one maximum supported base
+// page away from the ABI wrapper and every other function. It must remain a
+// leaf while the target page is writable and non-executable.
+
+	JMP	START
+	NOP65536
+START:
+	MOV	mProtect, A7
+	MOV	page+24(FP), A0
+	MOV	pageSize+32(FP), A1
+	MOV	protRW, A2
+	ECALL
+	BEQZ	A0, MPROTECT_OK
+	MOV	A0, ret+48(FP)
+	JMP	FINISH
+
+MPROTECT_OK:
+	MOV	target+0(FP), A0
+	MOV	data+8(FP), A1
+	MOV	len+16(FP), A2
+	BEQZ	A2, COPY_DONE
+	BEQ	A0, A1, COPY_DONE
+	BGTU	A0, A1, COPY_BACKWARD
+COPY_FORWARD:
+	MOVBU	0(A1), T1
+	MOVB	T1, 0(A0)
+	ADD	$1, A1
+	ADD	$1, A0
+	SUB	$1, A2
+	BNEZ	A2, COPY_FORWARD
+	JMP	COPY_DONE
+COPY_BACKWARD:
+	ADD	A0, A2, A0
+	ADD	A1, A2, A1
+COPY_BACKWARD_LOOP:
+	SUB	$1, A0
+	SUB	$1, A1
+	MOVBU	0(A1), T1
+	MOVB	T1, 0(A0)
+	SUB	$1, A2
+	BNEZ	A2, COPY_BACKWARD_LOOP
+
+COPY_DONE:
+	MOV	flushICache, A7
+	MOV	target+0(FP), A0
+	MOV	len+16(FP), A1
+	ADD	A0, A1, A1
+	MOV	$0, A2
+	ECALL
+	MOV	A0, ret+48(FP)
+
+	MOV	mProtect, A7
+	MOV	page+24(FP), A0
+	MOV	pageSize+32(FP), A1
+	MOV	oriProt+40(FP), A2
+	ECALL
+	BEQZ	A0, RESTORED
+
+	// Preserve the original restore error, then make one final RX attempt so
+	// the ABI wrapper remains executable even when it shares the target page.
+	MOV	A0, ret+48(FP)
+	MOV	mProtect, A7
+	MOV	page+24(FP), A0
+	MOV	pageSize+32(FP), A1
+	MOV	protRX, A2
+	ECALL
+	BEQZ	A0, RESTORED
+
+	// Returning through a wrapper on an NX page is impossible. Treat a failed
+	// emergency RX restore as unrecoverable instead of continuing corrupted.
+	WORD	$0x00000000
+
+RESTORED:
+	JMP	FINISH
+	NOP65536
+FINISH:
+	RET

--- a/internal/monkey/mem/write_linux_riscv64_test.go
+++ b/internal/monkey/mem/write_linux_riscv64_test.go
@@ -1,0 +1,255 @@
+//go:build linux && riscv64
+// +build linux,riscv64
+
+/*
+ * Copyright 2022 ByteDance Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package mem
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"reflect"
+	"runtime"
+	"strings"
+	"syscall"
+	"testing"
+
+	"github.com/bytedance/mockey/internal/monkey/common"
+)
+
+const (
+	writeOwnTextChild      = "MOCKEY_WRITE_OWN_TEXT_CHILD"
+	writeRestoreErrorChild = "MOCKEY_WRITE_RESTORE_ERROR_CHILD"
+)
+
+func TestWriteOwnTextPage(t *testing.T) {
+	if os.Getenv(writeOwnTextChild) == "1" {
+		pc := reflect.ValueOf(write).Pointer()
+		original := append([]byte(nil), common.BytesOf(pc, 4)...)
+		if err := Write(pc, original); err != nil {
+			t.Fatalf("write the writer's text page: %v", err)
+		}
+		return
+	}
+
+	cmd := exec.Command(os.Args[0], "-test.run=^TestWriteOwnTextPage$")
+	cmd.Env = append(os.Environ(), writeOwnTextChild+"=1")
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("writer text-page child failed: %v\n%s", err, output)
+	}
+}
+
+func TestWriteRestoreErrorKeepsWriterExecutable(t *testing.T) {
+	if os.Getenv(writeRestoreErrorChild) == "1" {
+		pc := reflect.ValueOf(write).Pointer()
+		original := append([]byte(nil), common.BytesOf(pc, 4)...)
+		result := write(
+			pc,
+			common.PtrOf(original),
+			len(original),
+			common.PageOf(pc),
+			common.PageSize(),
+			-1,
+		)
+		runtime.KeepAlive(original)
+		if result >= 0 {
+			t.Fatalf("invalid restore protection returned %d, want a negative errno", result)
+		}
+		if permissions := mappingPermissions(t, pc); !strings.HasPrefix(permissions, "r-x") {
+			t.Fatalf("writer page was not restored to RX: %q", permissions)
+		}
+
+		result = write(
+			pc,
+			common.PtrOf(original),
+			len(original),
+			common.PageOf(pc),
+			common.PageSize(),
+			syscall.PROT_READ|syscall.PROT_EXEC,
+		)
+		runtime.KeepAlive(original)
+		if result != 0 {
+			t.Fatalf("writer was not executable after fallback restore: %d", result)
+		}
+		return
+	}
+
+	cmd := exec.Command(os.Args[0], "-test.run=^TestWriteRestoreErrorKeepsWriterExecutable$")
+	cmd.Env = append(os.Environ(), writeRestoreErrorChild+"=1")
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("writer restore-error child failed: %v\n%s", err, output)
+	}
+}
+
+func TestWriteInitialMprotectFailureDoesNotModifyTarget(t *testing.T) {
+	pageSize := common.PageSize()
+	mapping, err := syscall.Mmap(
+		-1,
+		0,
+		pageSize,
+		syscall.PROT_READ|syscall.PROT_WRITE,
+		syscall.MAP_ANON|syscall.MAP_PRIVATE,
+	)
+	if err != nil {
+		t.Fatalf("mmap: %v", err)
+	}
+	defer func() {
+		if err := syscall.Munmap(mapping); err != nil {
+			t.Errorf("munmap: %v", err)
+		}
+	}()
+
+	original := []byte("original")
+	replacement := []byte("patched!")
+	copy(mapping, original)
+
+	result := write(
+		common.PtrOf(mapping),
+		common.PtrOf(replacement),
+		len(replacement),
+		1, // Deliberately unaligned: the first mprotect must fail before copying.
+		pageSize,
+		syscall.PROT_READ|syscall.PROT_EXEC,
+	)
+	runtime.KeepAlive(replacement)
+	if result >= 0 {
+		t.Fatalf("initial mprotect returned %d, want a negative errno", result)
+	}
+	if got := mapping[:len(original)]; !bytes.Equal(got, original) {
+		t.Fatalf("target changed after initial mprotect failure: got %q, want %q", got, original)
+	}
+}
+
+func TestWriteAcrossExecutablePages(t *testing.T) {
+	pageSize := common.PageSize()
+	mapping, err := syscall.Mmap(
+		-1,
+		0,
+		2*pageSize,
+		syscall.PROT_READ|syscall.PROT_WRITE,
+		syscall.MAP_ANON|syscall.MAP_PRIVATE,
+	)
+	if err != nil {
+		t.Fatalf("mmap: %v", err)
+	}
+	defer func() {
+		if err := syscall.Munmap(mapping); err != nil {
+			t.Errorf("munmap: %v", err)
+		}
+	}()
+
+	const bytesBeforeBoundary = 8
+	data := []byte{
+		0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17,
+		0x20, 0x21, 0x22, 0x23, 0x24, 0x25, 0x26, 0x27,
+		0x30, 0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37,
+	}
+	offset := pageSize - bytesBeforeBoundary
+	if err := syscall.Mprotect(mapping, syscall.PROT_READ|syscall.PROT_EXEC); err != nil {
+		t.Fatalf("mprotect RX: %v", err)
+	}
+
+	WriteWithSTW(common.PtrOf(mapping)+uintptr(offset), data)
+
+	if got := mapping[offset : offset+len(data)]; !bytes.Equal(got, data) {
+		t.Fatalf("cross-page write mismatch: got %x, want %x", got, data)
+	}
+	for _, addr := range []uintptr{
+		common.PtrOf(mapping),
+		common.PtrOf(mapping) + uintptr(pageSize),
+	} {
+		if perms := mappingPermissions(t, addr); !strings.HasPrefix(perms, "r-x") {
+			t.Fatalf("mapping at %#x was not restored to RX: %q", addr, perms)
+		}
+	}
+	t.Logf("validated executable cross-page write with %d-byte base pages", pageSize)
+}
+
+func TestWriteInlineMemmoveOverlap(t *testing.T) {
+	pageSize := common.PageSize()
+	mapping, err := syscall.Mmap(
+		-1,
+		0,
+		pageSize,
+		syscall.PROT_READ|syscall.PROT_WRITE,
+		syscall.MAP_ANON|syscall.MAP_PRIVATE,
+	)
+	if err != nil {
+		t.Fatalf("mmap: %v", err)
+	}
+	defer func() {
+		if err := syscall.Munmap(mapping); err != nil {
+			t.Errorf("munmap: %v", err)
+		}
+	}()
+
+	for _, test := range []struct {
+		name        string
+		destination int
+		source      int
+		want        string
+	}{
+		{name: "forward", destination: 0, source: 1, want: "bcdeff"},
+		{name: "backward", destination: 1, source: 0, want: "aabcde"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			copy(mapping, "abcdef")
+			res := write(
+				common.PtrOf(mapping)+uintptr(test.destination),
+				common.PtrOf(mapping)+uintptr(test.source),
+				5,
+				common.PageOf(common.PtrOf(mapping)),
+				pageSize,
+				syscall.PROT_READ|syscall.PROT_WRITE,
+			)
+			if res != 0 {
+				t.Fatalf("write returned %d", res)
+			}
+			if got := string(mapping[:6]); got != test.want {
+				t.Fatalf("overlap result: got %q, want %q", got, test.want)
+			}
+		})
+	}
+}
+
+func mappingPermissions(t *testing.T, addr uintptr) string {
+	t.Helper()
+
+	data, err := os.ReadFile("/proc/self/maps")
+	if err != nil {
+		t.Fatalf("read /proc/self/maps: %v", err)
+	}
+	for _, line := range strings.Split(string(data), "\n") {
+		fields := strings.Fields(line)
+		if len(fields) < 2 {
+			continue
+		}
+		var start, end uintptr
+		if _, err := fmt.Sscanf(fields[0], "%x-%x", &start, &end); err != nil {
+			continue
+		}
+		if start <= addr && addr < end {
+			return fields[1]
+		}
+	}
+	t.Fatalf("address %#x not found in /proc/self/maps", addr)
+	return ""
+}

--- a/internal/monkey/mem/write_test.go
+++ b/internal/monkey/mem/write_test.go
@@ -15,6 +15,8 @@ package mem
 // limitations under the License.
 
 import (
+	"bytes"
+	"errors"
 	"testing"
 
 	"github.com/bytedance/mockey/internal/monkey/common"
@@ -57,5 +59,186 @@ func TestWrite(t *testing.T) {
 		tool.Assert(begin+uintptr(len(data)) == expected[index][1], index, begin+uintptr(len(data)), expected[index][1])
 
 		break
+	}
+}
+
+func TestReplaceWithWriterRestoresAfterWriteError(t *testing.T) {
+	target := make([]byte, len("original"))
+	copy(target, "original")
+	original := append([]byte(nil), target...)
+	replacement := []byte("patched!")
+	applyErr := errors.New("injected apply failure")
+	calls := 0
+
+	state, err := replaceWithWriter(
+		common.PtrOf(target),
+		replacement,
+		original,
+		func(address uintptr, data []byte) error {
+			copy(common.BytesOf(address, len(data)), data)
+			calls++
+			if calls == 1 {
+				return applyErr
+			}
+			return nil
+		},
+	)
+
+	if state != ReplaceRestored {
+		t.Fatalf("state = %v, want ReplaceRestored", state)
+	}
+	if !errors.Is(err, applyErr) {
+		t.Fatalf("error = %v, want wrapped apply error", err)
+	}
+	if calls != 2 {
+		t.Fatalf("writer calls = %d, want 2", calls)
+	}
+	if !bytes.Equal(target, original) {
+		t.Fatalf("target = %q, want restored %q", target, original)
+	}
+}
+
+func TestReplaceWithWriterRollsBackAcrossPages(t *testing.T) {
+	pageSize := uintptr(common.PageSize())
+	storage := make([]byte, 3*common.PageSize())
+	base := common.PtrOf(storage)
+	boundary := common.PageOf(base+pageSize) + pageSize
+	targetAddress := boundary - 4
+	targetOffset := int(targetAddress - base)
+	target := storage[targetOffset : targetOffset+8]
+	copy(target, "original")
+	original := append([]byte(nil), target...)
+	replacement := []byte("patched!")
+	applyErr := errors.New("injected second-page failure")
+	calls := 0
+
+	state, err := replaceWithWriter(
+		targetAddress,
+		replacement,
+		original,
+		func(address uintptr, data []byte) error {
+			copy(common.BytesOf(address, len(data)), data)
+			calls++
+			if calls == 2 {
+				return applyErr
+			}
+			return nil
+		},
+	)
+
+	if state != ReplaceRestored {
+		t.Fatalf("state = %v, want ReplaceRestored", state)
+	}
+	if !errors.Is(err, applyErr) {
+		t.Fatalf("error = %v, want wrapped apply error", err)
+	}
+	if calls != 4 {
+		t.Fatalf("writer calls = %d, want 4", calls)
+	}
+	if !bytes.Equal(target, original) {
+		t.Fatalf("target = %q, want restored %q", target, original)
+	}
+}
+
+func TestReplaceWithWriterReportsUncertainRollback(t *testing.T) {
+	target := make([]byte, len("original"))
+	copy(target, "original")
+	original := append([]byte(nil), target...)
+	replacement := []byte("patched!")
+	applyErr := errors.New("injected apply failure")
+	rollbackErr := errors.New("injected rollback failure")
+	calls := 0
+
+	state, err := replaceWithWriter(
+		common.PtrOf(target),
+		replacement,
+		original,
+		func(address uintptr, data []byte) error {
+			copy(common.BytesOf(address, len(data)), data)
+			calls++
+			if calls == 1 {
+				return applyErr
+			}
+			return rollbackErr
+		},
+	)
+
+	if state != ReplaceUncertain {
+		t.Fatalf("state = %v, want ReplaceUncertain", state)
+	}
+	if !errors.Is(err, applyErr) {
+		t.Fatalf("error = %v, want wrapped apply error", err)
+	}
+	if err == nil || !bytes.Contains([]byte(err.Error()), []byte(rollbackErr.Error())) {
+		t.Fatalf("error = %v, want rollback failure", err)
+	}
+	if calls != 2 {
+		t.Fatalf("writer calls = %d, want 2", calls)
+	}
+}
+
+func TestReplaceWithWriterRejectsMismatchedLengths(t *testing.T) {
+	target := make([]byte, len("original"))
+	copy(target, "original")
+	original := append([]byte(nil), target...)
+	calls := 0
+
+	state, err := replaceWithWriter(
+		common.PtrOf(target),
+		[]byte("short"),
+		original,
+		func(uintptr, []byte) error {
+			calls++
+			return nil
+		},
+	)
+
+	if state != ReplaceRestored {
+		t.Fatalf("state = %v, want ReplaceRestored", state)
+	}
+	if err == nil {
+		t.Fatal("mismatched lengths returned no error")
+	}
+	if calls != 0 {
+		t.Fatalf("writer calls = %d, want 0", calls)
+	}
+	if !bytes.Equal(target, original) {
+		t.Fatalf("target = %q, want unchanged %q", target, original)
+	}
+}
+
+func TestReplaceWithWriterPropagatesPanicAfterMutation(t *testing.T) {
+	target := make([]byte, len("original"))
+	copy(target, "original")
+	original := append([]byte(nil), target...)
+	replacement := []byte("patched!")
+	panicValue := &struct{ message string }{message: "injected writer panic"}
+	calls := 0
+	var recovered interface{}
+
+	func() {
+		defer func() {
+			recovered = recover()
+		}()
+		_, _ = replaceWithWriter(
+			common.PtrOf(target),
+			replacement,
+			original,
+			func(address uintptr, data []byte) error {
+				copy(common.BytesOf(address, len(data)), data)
+				calls++
+				panic(panicValue)
+			},
+		)
+	}()
+
+	if recovered != panicValue {
+		t.Fatalf("panic = %#v, want original value %#v", recovered, panicValue)
+	}
+	if calls != 1 {
+		t.Fatalf("writer calls = %d, want 1 without rollback", calls)
+	}
+	if bytes.Equal(target, original) {
+		t.Fatalf("target was not modified before panic: %q", target)
 	}
 }

--- a/internal/monkey/patch.go
+++ b/internal/monkey/patch.go
@@ -18,6 +18,8 @@ package monkey
 
 import (
 	"reflect"
+	"runtime"
+	"sync"
 
 	"github.com/bytedance/mockey/internal/monkey/common"
 	"github.com/bytedance/mockey/internal/monkey/fn"
@@ -26,11 +28,52 @@ import (
 	"github.com/bytedance/mockey/internal/tool"
 )
 
+type replaceTargetFunc func(uintptr, []byte, []byte) (mem.ReplaceState, error)
+
+func invokeReplaceTarget(replaceTarget replaceTargetFunc, target uintptr, replacement, original []byte) (state mem.ReplaceState, panicked bool, recovered interface{}, err error) {
+	panicked = true
+	defer func() {
+		recovered = recover()
+	}()
+
+	state, err = replaceTarget(target, replacement, original)
+	panicked = false
+	return
+}
+
+type failedPatch struct {
+	patch *Patch
+	cause interface{}
+}
+
+var patchRegistry = struct {
+	sync.Mutex
+	byTarget       map[uintptr][]*Patch
+	failedByTarget map[uintptr]*failedPatch
+}{
+	byTarget:       make(map[uintptr][]*Patch),
+	failedByTarget: make(map[uintptr]*failedPatch),
+}
+
+// IsPatchTargetPoisoned reports whether a failed replacement left target in an
+// uncertain state. Callers must retain all hook and proxy references while it is true.
+func IsPatchTargetPoisoned(target uintptr) bool {
+	patchRegistry.Lock()
+	defer patchRegistry.Unlock()
+	_, poisoned := patchRegistry.failedByTarget[target]
+	return poisoned
+}
+
 // Patch is a context that holds the address and original codes of the patched function.
 type Patch struct {
-	size int
-	code []byte
-	base uintptr
+	size          int
+	code          []byte
+	original      []byte
+	installed     []byte
+	base          uintptr
+	hook          reflect.Value
+	proxy         reflect.Value
+	previousProxy reflect.Value
 }
 
 // Base returns the address of the patched function.
@@ -40,37 +83,169 @@ func (p *Patch) Base() uintptr {
 
 // Unpatch restores the patched function to the original function.
 func (p *Patch) Unpatch() {
-	mem.WriteWithSTW(p.base, p.code[:p.size])
-	common.ReleasePage(p.code)
+	p.unpatch(mem.ReplaceWithSTW, inst.ReleaseProxy)
+}
+
+func (p *Patch) unpatch(replaceTarget replaceTargetFunc, releaseProxy func([]byte)) {
+	patchRegistry.Lock()
+	defer patchRegistry.Unlock()
+
+	if failed, poisoned := patchRegistry.failedByTarget[p.base]; poisoned {
+		runtime.KeepAlive(failed.patch)
+		tool.Assert(false, "patch target %#x is in an uncertain state after: %v", p.base, failed.cause)
+	}
+
+	stack := patchRegistry.byTarget[p.base]
+	tool.Assert(
+		len(stack) > 0 && stack[len(stack)-1] == p,
+		"patches at %#x must be unpatched in reverse creation order",
+		p.base,
+	)
+
+	state, panicked, recovered, err := invokeReplaceTarget(replaceTarget, p.base, p.original[:p.size], p.installed)
+	if panicked {
+		patchRegistry.failedByTarget[p.base] = &failedPatch{patch: p, cause: recovered}
+		panic(recovered)
+	}
+	switch state {
+	case mem.ReplaceApplied:
+		if err != nil {
+			patchRegistry.failedByTarget[p.base] = &failedPatch{patch: p, cause: err}
+			tool.Assert(false, "restoring patch at %#x returned an inconsistent error: %v", p.base, err)
+			return
+		}
+	case mem.ReplaceRestored:
+		tool.Assert(err != nil, "restoring patch at %#x failed without an error", p.base)
+		tool.Assert(false, "restore patch at %#x failed; installed bytes were restored: %v", p.base, err)
+		return
+	case mem.ReplaceUncertain:
+		patchRegistry.failedByTarget[p.base] = &failedPatch{patch: p, cause: err}
+		tool.Assert(err != nil, "restoring patch at %#x became uncertain without an error", p.base)
+		tool.Assert(false, "restore patch at %#x left the target in an uncertain state: %v", p.base, err)
+		return
+	default:
+		patchRegistry.failedByTarget[p.base] = &failedPatch{patch: p, cause: err}
+		tool.Assert(false, "restore patch at %#x returned invalid state %d", p.base, state)
+		return
+	}
+
+	p.proxy.Elem().Set(p.previousProxy)
+	releaseProxy(p.code)
+	if len(stack) == 1 {
+		delete(patchRegistry.byTarget, p.base)
+	} else {
+		patchRegistry.byTarget[p.base] = stack[:len(stack)-1]
+	}
+	p.code = nil
+	p.installed = nil
+	p.hook = reflect.Value{}
+	p.proxy = reflect.Value{}
+	p.previousProxy = reflect.Value{}
 }
 
 // PatchValue replace the target function with a hook function, and stores the target function in the proxy function
 // for future restore. Target and hook are values of function. Proxy is a value of proxy function pointer.
 func PatchValue(target, hook, proxy reflect.Value, unsafe bool) *Patch {
+	return patchValue(target, hook, proxy, unsafe, mem.ReplaceWithSTW, inst.ReleaseProxy)
+}
+
+func patchValue(target, hook, proxy reflect.Value, unsafe bool, replaceTarget replaceTargetFunc, releaseProxy func([]byte)) *Patch {
 	tool.Assert(hook.Kind() == reflect.Func, "'%s' is not a function", hook.Kind())
 	tool.Assert(proxy.Kind() == reflect.Ptr, "'%v' is not a function pointer", proxy.Kind())
+	tool.Assert(proxy.Elem().Kind() == reflect.Func, "'%v' is not a function pointer", proxy.Elem().Kind())
 
 	targetAddr := target.Pointer()
-	// The first few bytes of the target function code
-	const bufSize = 64
-	targetCodeBuf := common.BytesOf(targetAddr, bufSize)
-	// construct the branch instruction, i.e. jump to the hook function
-	hookCode := inst.BranchInto(common.PtrAt(hook))
-	// construct the proxy code
-	proxyCode := common.AllocatePage()
-	tool.DebugPrintf("PatchValue: target addr(0x%x), proxy addr(%p), hook code len(%v)\n", targetAddr, &proxyCode[0], len(hookCode))
-	// search the cutting point of the target code, i.e. the minimum length of full instructions that is longer than the hookCode
-	cuttingIdx := inst.Disassemble(targetCodeBuf, len(hookCode), !unsafe)
-	// save the original code before the cutting point
-	copy(proxyCode, targetCodeBuf[:cuttingIdx])
-	// construct the branch instruction, i.e. jump to the cutting point
-	copy(proxyCode[cuttingIdx:], inst.BranchTo(targetAddr+uintptr(cuttingIdx)))
-	// inject the proxy code to the proxy function
-	fn.InjectInto(proxy, proxyCode)
-	// replace target function codes before the cutting point
-	mem.WriteWithSTW(targetAddr, hookCode)
+	patchRegistry.Lock()
+	defer patchRegistry.Unlock()
+	if failed, poisoned := patchRegistry.failedByTarget[targetAddr]; poisoned {
+		runtime.KeepAlive(failed.patch)
+		tool.Assert(false, "patch target %#x is in an uncertain state after: %v", targetAddr, failed.cause)
+	}
 
-	return &Patch{base: targetAddr, code: proxyCode, size: cuttingIdx}
+	targetCodeBuf := common.BytesOf(targetAddr, inst.MaxPatchSize())
+	cuttingIdx := inst.PatchSize(targetAddr, targetCodeBuf, !unsafe)
+	originalCode := append([]byte(nil), targetCodeBuf[:cuttingIdx]...)
+	previousProxy := reflect.New(proxy.Elem().Type()).Elem()
+	previousProxy.Set(proxy.Elem())
+
+	proxyCode := inst.AllocateProxy(targetAddr)
+	releaseOnFailure := true
+	proxyInjected := false
+	defer func() {
+		if !releaseOnFailure {
+			return
+		}
+		if proxyInjected {
+			proxy.Elem().Set(previousProxy)
+		}
+		releaseProxy(proxyCode)
+	}()
+
+	proxyAddr := common.PtrOf(proxyCode)
+	proxyBody, targetPatch := inst.BuildPatch(
+		targetAddr,
+		proxyAddr,
+		common.PtrAt(hook),
+		originalCode,
+	)
+	tool.Assert(len(proxyBody) <= len(proxyCode), "proxy code is too large: %d > %d", len(proxyBody), len(proxyCode))
+	tool.Assert(len(targetPatch) <= len(originalCode), "target patch is too large: %d > %d", len(targetPatch), len(originalCode))
+	copy(proxyCode, proxyBody)
+	installedCode := append([]byte(nil), originalCode...)
+	copy(installedCode, targetPatch)
+	tool.DebugPrintf(
+		"PatchValue: target addr(0x%x), proxy addr(%p), target patch len(%v)\n",
+		targetAddr,
+		&proxyCode[0],
+		len(installedCode),
+	)
+
+	patch := &Patch{
+		size:          cuttingIdx,
+		code:          proxyCode,
+		original:      originalCode,
+		installed:     installedCode,
+		base:          targetAddr,
+		hook:          hook,
+		proxy:         proxy,
+		previousProxy: previousProxy,
+	}
+	fn.InjectInto(proxy, proxyCode)
+	proxyInjected = true
+
+	state, panicked, recovered, err := invokeReplaceTarget(replaceTarget, targetAddr, installedCode, originalCode)
+	if panicked {
+		patchRegistry.failedByTarget[targetAddr] = &failedPatch{patch: patch, cause: recovered}
+		releaseOnFailure = false
+		panic(recovered)
+	}
+	switch state {
+	case mem.ReplaceApplied:
+		if err != nil {
+			patchRegistry.failedByTarget[targetAddr] = &failedPatch{patch: patch, cause: err}
+			releaseOnFailure = false
+			tool.Assert(false, "installing patch at %#x returned an inconsistent error: %v", targetAddr, err)
+			return nil
+		}
+		patchRegistry.byTarget[targetAddr] = append(patchRegistry.byTarget[targetAddr], patch)
+		releaseOnFailure = false
+		return patch
+	case mem.ReplaceRestored:
+		tool.Assert(err != nil, "installing patch at %#x failed without an error", targetAddr)
+		tool.Assert(false, "install patch at %#x failed; original bytes were restored: %v", targetAddr, err)
+		return nil
+	case mem.ReplaceUncertain:
+		patchRegistry.failedByTarget[targetAddr] = &failedPatch{patch: patch, cause: err}
+		releaseOnFailure = false
+		tool.Assert(err != nil, "installing patch at %#x became uncertain without an error", targetAddr)
+		tool.Assert(false, "install patch at %#x left the target in an uncertain state: %v", targetAddr, err)
+		return nil
+	default:
+		patchRegistry.failedByTarget[targetAddr] = &failedPatch{patch: patch, cause: err}
+		releaseOnFailure = false
+		tool.Assert(false, "install patch at %#x returned invalid state %d", targetAddr, state)
+		return nil
+	}
 }
 
 func PatchFunc(fn, hook, proxy interface{}, unsafe bool) *Patch {

--- a/internal/monkey/patch_riscv64_test.go
+++ b/internal/monkey/patch_riscv64_test.go
@@ -1,0 +1,140 @@
+//go:build riscv64
+// +build riscv64
+
+/*
+ * Copyright 2022 ByteDance Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package monkey
+
+import (
+	"os"
+	"os/exec"
+	"runtime"
+	"testing"
+	"time"
+	"unsafe"
+)
+
+const proxyPointerStackChild = "MOCKEY_PROXY_POINTER_STACK_CHILD"
+
+//go:noinline
+func originMorestackTarget(value int) int {
+	var padding [128 << 10]byte
+	padding[0] = byte(value)
+	padding[len(padding)-1] = byte(value >> 8)
+	runtime.KeepAlive(&padding)
+	return value + 1 + int(padding[0]) + int(padding[len(padding)-1])
+}
+
+func TestProxyRelocatesMorestackCall(t *testing.T) {
+	var proxy func(int) int
+	patch := PatchFunc(
+		originMorestackTarget,
+		func(int) int { return -1 },
+		&proxy,
+		false,
+	)
+	defer patch.Unpatch()
+
+	input := 0x123
+	result := make(chan int, 1)
+	go func() {
+		result <- proxy(input)
+	}()
+
+	select {
+	case got := <-result:
+		want := input + 1 + int(byte(input)) + int(byte(input>>8))
+		if got != want {
+			t.Fatalf("origin proxy result: got %d, want %d", got, want)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("origin proxy did not return after stack growth")
+	}
+}
+
+// hideStackPointer hides pointer provenance from escape analysis so the
+// regression exercises a stack pointer.
+//
+//go:noescape
+func hideStackPointer(pointer unsafe.Pointer) unsafe.Pointer
+
+//go:noinline
+func originMorestackPointerTarget(pointer *int) uintptr {
+	var padding [128 << 10]byte
+	padding[0] = byte(*pointer)
+	padding[len(padding)-1] = byte(*pointer)
+	runtime.KeepAlive(&padding)
+	return uintptr(unsafe.Pointer(pointer))
+}
+
+func TestProxyMorestackAdjustsPointerArgument(t *testing.T) {
+	if os.Getenv(proxyPointerStackChild) != "1" {
+		cmd := exec.Command(
+			os.Args[0],
+			"-test.run=^TestProxyMorestackAdjustsPointerArgument$",
+		)
+		cmd.Env = append(os.Environ(), proxyPointerStackChild+"=1")
+		if output, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("pointer stack-growth child failed: %v\n%s", err, output)
+		}
+		return
+	}
+
+	var proxy func(*int) uintptr
+	patch := PatchFunc(
+		originMorestackPointerTarget,
+		func(*int) uintptr { return 0 },
+		&proxy,
+		false,
+	)
+	defer patch.Unpatch()
+
+	type result struct {
+		before uintptr
+		got    uintptr
+		after  uintptr
+	}
+	results := make(chan result, 1)
+	go func() {
+		value := 123
+		before := uintptr(unsafe.Pointer(&value))
+		pointer := (*int)(hideStackPointer(unsafe.Pointer(&value)))
+		got := proxy(pointer)
+		results <- result{
+			before: before,
+			got:    got,
+			after:  uintptr(unsafe.Pointer(&value)),
+		}
+	}()
+
+	select {
+	case got := <-results:
+		if got.before == got.after {
+			t.Fatal("test did not move the goroutine stack")
+		}
+		if got.got != got.after {
+			t.Fatalf(
+				"pointer argument was not adjusted: before=%#x got=%#x after=%#x",
+				got.before,
+				got.got,
+				got.after,
+			)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("origin proxy did not return after pointer-bearing stack growth")
+	}
+}

--- a/internal/monkey/patch_test.go
+++ b/internal/monkey/patch_test.go
@@ -17,10 +17,16 @@
 package monkey
 
 import (
+	"errors"
+	"os"
+	"os/exec"
 	"reflect"
+	"runtime"
 	"strings"
 	"testing"
 
+	"github.com/bytedance/mockey/internal/monkey/inst"
+	"github.com/bytedance/mockey/internal/monkey/mem"
 	. "github.com/smartystreets/goconvey/convey"
 )
 
@@ -73,4 +79,695 @@ func TestPatchFunc(t *testing.T) {
 			So(Target("anything"), ShouldEqual, "anything")
 		})
 	})
+}
+
+func LifecycleTarget(in string) string {
+	return strings.Repeat(in, 1)
+}
+
+func catchPanic(f func()) (recovered interface{}) {
+	defer func() {
+		recovered = recover()
+	}()
+	f()
+	return nil
+}
+
+func catchPanicState(f func()) (panicked bool, recovered interface{}) {
+	panicked = true
+	defer func() {
+		recovered = recover()
+	}()
+	f()
+	panicked = false
+	return
+}
+
+func cleanupPoisonedTarget(t *testing.T, target uintptr) {
+	t.Helper()
+
+	patchRegistry.Lock()
+	failed, ok := patchRegistry.failedByTarget[target]
+	if !ok {
+		patchRegistry.Unlock()
+		t.Fatalf("target %#x is not quarantined", target)
+		return
+	}
+	patch := failed.patch
+	mem.WriteWithSTW(patch.base, patch.original[:patch.size])
+	patch.proxy.Elem().Set(patch.previousProxy)
+	inst.ReleaseProxy(patch.code)
+	delete(patchRegistry.failedByTarget, target)
+	stack := patchRegistry.byTarget[target]
+	if len(stack) > 0 && stack[len(stack)-1] == patch {
+		if len(stack) == 1 {
+			delete(patchRegistry.byTarget, target)
+		} else {
+			patchRegistry.byTarget[target] = stack[:len(stack)-1]
+		}
+	}
+	patch.code = nil
+	patch.installed = nil
+	patch.hook = reflect.Value{}
+	patch.proxy = reflect.Value{}
+	patch.previousProxy = reflect.Value{}
+	patchRegistry.Unlock()
+}
+
+func TestPatchInstallFailureRestoresProxy(t *testing.T) {
+	previousProxy := func(in string) string { return "previous:" + in }
+	proxy := previousProxy
+	injectedErr := errors.New("injected install failure")
+	releases := 0
+
+	recovered := catchPanic(func() {
+		patchValue(
+			reflect.ValueOf(LifecycleTarget),
+			reflect.ValueOf(Hook),
+			reflect.ValueOf(&proxy),
+			false,
+			func(uintptr, []byte, []byte) (mem.ReplaceState, error) {
+				return mem.ReplaceRestored, injectedErr
+			},
+			func(code []byte) {
+				releases++
+				inst.ReleaseProxy(code)
+			},
+		)
+	})
+
+	if recovered == nil {
+		t.Fatal("patchValue did not panic")
+	}
+	if releases != 1 {
+		t.Fatalf("proxy releases = %d, want 1", releases)
+	}
+	if got := proxy("value"); got != "previous:value" {
+		t.Fatalf("proxy was not restored: got %q", got)
+	}
+	if got := LifecycleTarget("value"); got != "value" {
+		t.Fatalf("target changed after restored failure: got %q", got)
+	}
+	target := reflect.ValueOf(LifecycleTarget).Pointer()
+	patchRegistry.Lock()
+	_, registered := patchRegistry.byTarget[target]
+	_, poisoned := patchRegistry.failedByTarget[target]
+	patchRegistry.Unlock()
+	if registered || poisoned {
+		t.Fatalf("restored failure left registry state: registered=%v poisoned=%v", registered, poisoned)
+	}
+}
+
+func TestPatchInstallUncertainQuarantinesReferences(t *testing.T) {
+	var proxy func(string) string
+	injectedErr := errors.New("injected uncertain install")
+	releases := 0
+	target := reflect.ValueOf(LifecycleTarget).Pointer()
+	cleaned := false
+	defer func() {
+		if !cleaned {
+			cleanupPoisonedTarget(t, target)
+		}
+	}()
+
+	recovered := catchPanic(func() {
+		patchValue(
+			reflect.ValueOf(LifecycleTarget),
+			reflect.ValueOf(Hook),
+			reflect.ValueOf(&proxy),
+			false,
+			func(uintptr, []byte, []byte) (mem.ReplaceState, error) {
+				return mem.ReplaceUncertain, injectedErr
+			},
+			func(code []byte) {
+				releases++
+				inst.ReleaseProxy(code)
+			},
+		)
+	})
+
+	if recovered == nil {
+		t.Fatal("patchValue did not panic")
+	}
+	if releases != 0 {
+		t.Fatalf("uncertain proxy releases = %d, want 0", releases)
+	}
+	patchRegistry.Lock()
+	failed := patchRegistry.failedByTarget[target]
+	patchRegistry.Unlock()
+	if failed == nil || !failed.patch.hook.IsValid() || !failed.patch.proxy.IsValid() {
+		t.Fatal("uncertain patch did not retain hook and proxy")
+	}
+
+	for i := 0; i < 3; i++ {
+		runtime.GC()
+	}
+	if proxy == nil {
+		t.Fatal("uncertain patch did not retain the injected proxy")
+	}
+	if got := proxy("value"); got != "value" {
+		t.Fatalf("retained proxy returned %q, want original value", got)
+	}
+	var secondProxy func(string) string
+	if catchPanic(func() {
+		PatchFunc(LifecycleTarget, Hook, &secondProxy, false)
+	}) == nil {
+		t.Fatal("poisoned target accepted another patch")
+	}
+
+	cleanupPoisonedTarget(t, target)
+	cleaned = true
+	if proxy != nil {
+		t.Fatal("cleanup did not restore the previous nil proxy")
+	}
+	if got := LifecycleTarget("value"); got != "value" {
+		t.Fatalf("cleanup did not restore target: got %q", got)
+	}
+}
+
+func TestUnpatchFailureKeepsPatchRetryable(t *testing.T) {
+	var proxy func(string) string
+	patch := PatchFunc(LifecycleTarget, Hook, &proxy, false)
+	injectedErr := errors.New("injected restore failure")
+	releases := 0
+
+	recovered := catchPanic(func() {
+		patch.unpatch(
+			func(uintptr, []byte, []byte) (mem.ReplaceState, error) {
+				return mem.ReplaceRestored, injectedErr
+			},
+			func(code []byte) {
+				releases++
+				inst.ReleaseProxy(code)
+			},
+		)
+	})
+	if recovered == nil {
+		t.Fatal("Unpatch did not panic")
+	}
+	if releases != 0 {
+		t.Fatalf("proxy releases = %d, want 0", releases)
+	}
+	if got := LifecycleTarget("value"); got != "MOCKED!" {
+		t.Fatalf("patch was not kept active: got %q", got)
+	}
+	if proxy == nil {
+		t.Fatal("proxy was cleared after retryable failure")
+	}
+
+	patch.Unpatch()
+	if got := LifecycleTarget("value"); got != "value" {
+		t.Fatalf("retry did not restore target: got %q", got)
+	}
+	if proxy != nil {
+		t.Fatal("successful retry did not restore nil proxy")
+	}
+}
+
+func TestUnpatchUncertainPoisonsTarget(t *testing.T) {
+	var proxy func(string) string
+	patch := PatchFunc(LifecycleTarget, Hook, &proxy, false)
+	target := patch.Base()
+	injectedErr := errors.New("injected uncertain restore")
+	cleaned := false
+	defer func() {
+		if !cleaned {
+			cleanupPoisonedTarget(t, target)
+		}
+	}()
+
+	if catchPanic(func() {
+		patch.unpatch(
+			func(uintptr, []byte, []byte) (mem.ReplaceState, error) {
+				return mem.ReplaceUncertain, injectedErr
+			},
+			inst.ReleaseProxy,
+		)
+	}) == nil {
+		t.Fatal("uncertain Unpatch did not panic")
+	}
+	if got := LifecycleTarget("value"); got != "MOCKED!" {
+		t.Fatalf("uncertain Unpatch unexpectedly disabled patch: got %q", got)
+	}
+	if catchPanic(patch.Unpatch) == nil {
+		t.Fatal("poisoned target allowed another Unpatch")
+	}
+
+	cleanupPoisonedTarget(t, target)
+	cleaned = true
+	if proxy != nil {
+		t.Fatal("cleanup did not restore nil proxy")
+	}
+	if got := LifecycleTarget("value"); got != "value" {
+		t.Fatalf("cleanup did not restore target: got %q", got)
+	}
+}
+
+func TestPatchLayersRequireLIFO(t *testing.T) {
+	var firstProxy, secondProxy func(string) string
+	first := PatchFunc(
+		LifecycleTarget,
+		func(string) string { return "first" },
+		&firstProxy,
+		false,
+	)
+	second := PatchFunc(
+		LifecycleTarget,
+		func(string) string { return "second" },
+		&secondProxy,
+		false,
+	)
+	firstActive, secondActive := true, true
+	defer func() {
+		if secondActive {
+			second.Unpatch()
+		}
+		if firstActive {
+			first.Unpatch()
+		}
+	}()
+
+	if got := LifecycleTarget("value"); got != "second" {
+		t.Fatalf("top patch returned %q, want second", got)
+	}
+	if catchPanic(first.Unpatch) == nil {
+		t.Fatal("non-LIFO Unpatch did not panic")
+	}
+	if got := LifecycleTarget("value"); got != "second" {
+		t.Fatalf("non-LIFO attempt changed target: got %q", got)
+	}
+
+	second.Unpatch()
+	secondActive = false
+	if got := LifecycleTarget("value"); got != "first" {
+		t.Fatalf("removing top patch returned %q, want first", got)
+	}
+
+	first.Unpatch()
+	firstActive = false
+	if got := LifecycleTarget("value"); got != "value" {
+		t.Fatalf("removing all patches returned %q, want original", got)
+	}
+}
+
+func installClosurePatch() (*Patch, *func(string) string) {
+	proxy := new(func(string) string)
+	prefix := "retained:"
+	patch := PatchFunc(
+		LifecycleTarget,
+		func(in string) string { return prefix + in },
+		proxy,
+		false,
+	)
+	return patch, proxy
+}
+
+func TestPatchKeepsClosureHookAlive(t *testing.T) {
+	patch, proxy := installClosurePatch()
+	active := true
+	defer func() {
+		if active {
+			patch.Unpatch()
+		}
+	}()
+
+	for i := 0; i < 5; i++ {
+		runtime.GC()
+	}
+	if got := LifecycleTarget("value"); got != "retained:value" {
+		t.Fatalf("hook after GC returned %q", got)
+	}
+	if *proxy == nil || (*proxy)("value") != "value" {
+		t.Fatal("origin proxy was not kept alive")
+	}
+
+	patch.Unpatch()
+	active = false
+	if *proxy != nil {
+		t.Fatal("Unpatch did not restore the previous nil proxy")
+	}
+	if got := LifecycleTarget("value"); got != "value" {
+		t.Fatalf("Unpatch returned %q, want original", got)
+	}
+}
+
+func TestPatchInstallPanicQuarantinesMutatedTarget(t *testing.T) {
+	var proxy func(string) string
+	panicValue := &struct{ operation string }{operation: "install"}
+	releases := 0
+	target := reflect.ValueOf(LifecycleTarget).Pointer()
+	cleaned := false
+	defer func() {
+		if !cleaned {
+			cleanupPoisonedTarget(t, target)
+		}
+	}()
+
+	recovered := catchPanic(func() {
+		patchValue(
+			reflect.ValueOf(LifecycleTarget),
+			reflect.ValueOf(func(in string) string { return "panic:" + in }),
+			reflect.ValueOf(&proxy),
+			false,
+			func(target uintptr, replacement, _ []byte) (mem.ReplaceState, error) {
+				mem.WriteWithSTW(target, replacement)
+				panic(panicValue)
+			},
+			func(code []byte) {
+				releases++
+				inst.ReleaseProxy(code)
+			},
+		)
+	})
+
+	if recovered != panicValue {
+		t.Fatalf("panic = %#v, want original value %#v", recovered, panicValue)
+	}
+	if releases != 0 {
+		t.Fatalf("proxy releases = %d, want 0", releases)
+	}
+	patchRegistry.Lock()
+	failed := patchRegistry.failedByTarget[target]
+	patchRegistry.Unlock()
+	if failed == nil {
+		t.Fatal("panic after target mutation was not quarantined")
+	}
+	if failed.cause != panicValue {
+		t.Fatalf("quarantine cause = %#v, want %#v", failed.cause, panicValue)
+	}
+	if !failed.patch.hook.IsValid() || !failed.patch.proxy.IsValid() {
+		t.Fatal("quarantine did not retain hook and proxy")
+	}
+
+	for i := 0; i < 3; i++ {
+		runtime.GC()
+	}
+	if got := LifecycleTarget("value"); got != "panic:value" {
+		t.Fatalf("quarantined hook after GC returned %q", got)
+	}
+	if proxy == nil || proxy("value") != "value" {
+		t.Fatal("quarantined origin proxy was not executable")
+	}
+	var secondProxy func(string) string
+	if catchPanic(func() {
+		PatchFunc(LifecycleTarget, Hook, &secondProxy, false)
+	}) == nil {
+		t.Fatal("quarantined target accepted another patch")
+	}
+
+	cleanupPoisonedTarget(t, target)
+	cleaned = true
+	if proxy != nil {
+		t.Fatal("cleanup did not restore nil proxy")
+	}
+	if got := LifecycleTarget("value"); got != "value" {
+		t.Fatalf("cleanup returned %q, want original", got)
+	}
+}
+
+func TestUnpatchPanicQuarantinesMutatedTarget(t *testing.T) {
+	var proxy func(string) string
+	patch := PatchFunc(
+		LifecycleTarget,
+		func(in string) string { return "patched:" + in },
+		&proxy,
+		false,
+	)
+	target := patch.Base()
+	panicValue := &struct{ operation string }{operation: "unpatch"}
+	releases := 0
+	cleaned := false
+	defer func() {
+		if !cleaned {
+			cleanupPoisonedTarget(t, target)
+		}
+	}()
+
+	recovered := catchPanic(func() {
+		patch.unpatch(
+			func(target uintptr, original, _ []byte) (mem.ReplaceState, error) {
+				mem.WriteWithSTW(target, original)
+				panic(panicValue)
+			},
+			func(code []byte) {
+				releases++
+				inst.ReleaseProxy(code)
+			},
+		)
+	})
+
+	if recovered != panicValue {
+		t.Fatalf("panic = %#v, want original value %#v", recovered, panicValue)
+	}
+	if releases != 0 {
+		t.Fatalf("proxy releases = %d, want 0", releases)
+	}
+	patchRegistry.Lock()
+	failed := patchRegistry.failedByTarget[target]
+	stack := patchRegistry.byTarget[target]
+	patchRegistry.Unlock()
+	if failed == nil || failed.patch != patch {
+		t.Fatal("panic during Unpatch was not quarantined")
+	}
+	if failed.cause != panicValue {
+		t.Fatalf("quarantine cause = %#v, want %#v", failed.cause, panicValue)
+	}
+	if len(stack) == 0 || stack[len(stack)-1] != patch {
+		t.Fatal("panic during Unpatch popped the active patch")
+	}
+
+	for i := 0; i < 3; i++ {
+		runtime.GC()
+	}
+	if got := LifecycleTarget("value"); got != "value" {
+		t.Fatalf("fake Unpatch did not mutate target: got %q", got)
+	}
+	if proxy == nil || proxy("value") != "value" {
+		t.Fatal("panic during Unpatch released or reset proxy")
+	}
+	if catchPanic(patch.Unpatch) == nil {
+		t.Fatal("quarantined patch allowed another Unpatch")
+	}
+	var secondProxy func(string) string
+	if catchPanic(func() {
+		PatchFunc(LifecycleTarget, Hook, &secondProxy, false)
+	}) == nil {
+		t.Fatal("quarantined target accepted another patch")
+	}
+
+	cleanupPoisonedTarget(t, target)
+	cleaned = true
+	if proxy != nil {
+		t.Fatal("cleanup did not restore nil proxy")
+	}
+	if got := LifecycleTarget("value"); got != "value" {
+		t.Fatalf("cleanup returned %q, want original", got)
+	}
+}
+
+const panicNilChildEnv = "MOCKEY_PANIC_NIL_CHILD"
+
+func targetIsQuarantined(target uintptr) bool {
+	patchRegistry.Lock()
+	defer patchRegistry.Unlock()
+	_, quarantined := patchRegistry.failedByTarget[target]
+	return quarantined
+}
+
+func TestReplaceTargetNilPanicIsQuarantined(t *testing.T) {
+	if os.Getenv(panicNilChildEnv) != "1" {
+		cmd := exec.Command(os.Args[0], "-test.run=^TestReplaceTargetNilPanicIsQuarantined$")
+		environment := make([]string, 0, len(os.Environ())+2)
+		for _, entry := range os.Environ() {
+			if strings.HasPrefix(entry, "GODEBUG=") ||
+				strings.HasPrefix(entry, panicNilChildEnv+"=") {
+				continue
+			}
+			environment = append(environment, entry)
+		}
+		cmd.Env = append(environment, "GODEBUG=panicnil=1", panicNilChildEnv+"=1")
+		output, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("panic(nil) child process failed: %v\n%s", err, output)
+		}
+		return
+	}
+
+	panicked, recovered := catchPanicState(func() {
+		panic(nil)
+	})
+	if !panicked || recovered != nil {
+		t.Fatalf("GODEBUG=panicnil=1 is not active: panicked=%v recovered=%#v", panicked, recovered)
+	}
+
+	t.Run("install", testPatchInstallNilPanicQuarantines)
+	t.Run("unpatch", testUnpatchNilPanicQuarantines)
+}
+
+func testPatchInstallNilPanicQuarantines(t *testing.T) {
+	var proxy func(string) string
+	var installed *Patch
+	target := reflect.ValueOf(LifecycleTarget).Pointer()
+	releases := 0
+	cleaned := false
+	defer func() {
+		if cleaned {
+			return
+		}
+		if targetIsQuarantined(target) {
+			cleanupPoisonedTarget(t, target)
+		} else if installed != nil {
+			installed.Unpatch()
+		}
+	}()
+
+	panicked, recovered := catchPanicState(func() {
+		installed = patchValue(
+			reflect.ValueOf(LifecycleTarget),
+			reflect.ValueOf(func(in string) string { return "nil-panic:" + in }),
+			reflect.ValueOf(&proxy),
+			false,
+			func(target uintptr, replacement, _ []byte) (mem.ReplaceState, error) {
+				mem.WriteWithSTW(target, replacement)
+				panic(nil)
+			},
+			func(code []byte) {
+				releases++
+				inst.ReleaseProxy(code)
+			},
+		)
+	})
+
+	if !panicked {
+		t.Fatal("panic(nil) during patch installation was treated as ReplaceApplied")
+	}
+	if recovered != nil {
+		t.Fatalf("recovered panic value = %#v, want nil", recovered)
+	}
+	if installed != nil {
+		t.Fatal("patch installation returned a patch after panic(nil)")
+	}
+	if releases != 0 {
+		t.Fatalf("proxy releases = %d, want 0", releases)
+	}
+
+	patchRegistry.Lock()
+	failed := patchRegistry.failedByTarget[target]
+	_, registered := patchRegistry.byTarget[target]
+	patchRegistry.Unlock()
+	if failed == nil {
+		t.Fatal("panic(nil) during patch installation was not quarantined")
+	}
+	if failed.cause != nil {
+		t.Fatalf("quarantine cause = %#v, want nil", failed.cause)
+	}
+	if registered {
+		t.Fatal("panicking patch installation was registered as applied")
+	}
+	if !failed.patch.hook.IsValid() || !failed.patch.proxy.IsValid() {
+		t.Fatal("quarantine did not retain the hook and proxy")
+	}
+	if got := LifecycleTarget("value"); got != "nil-panic:value" {
+		t.Fatalf("mutated target returned %q, want quarantined hook", got)
+	}
+	if proxy == nil || proxy("value") != "value" {
+		t.Fatal("quarantined origin proxy is not executable")
+	}
+
+	var secondProxy func(string) string
+	secondPanicked, _ := catchPanicState(func() {
+		PatchFunc(LifecycleTarget, Hook, &secondProxy, false)
+	})
+	if !secondPanicked {
+		t.Fatal("quarantined target accepted another patch")
+	}
+
+	cleanupPoisonedTarget(t, target)
+	cleaned = true
+	if proxy != nil {
+		t.Fatal("cleanup did not restore the nil proxy")
+	}
+	if got := LifecycleTarget("value"); got != "value" {
+		t.Fatalf("cleanup returned %q, want original", got)
+	}
+}
+
+func testUnpatchNilPanicQuarantines(t *testing.T) {
+	var proxy func(string) string
+	patch := PatchFunc(
+		LifecycleTarget,
+		func(in string) string { return "patched:" + in },
+		&proxy,
+		false,
+	)
+	target := patch.Base()
+	releases := 0
+	active := true
+	cleaned := false
+	defer func() {
+		if cleaned {
+			return
+		}
+		if targetIsQuarantined(target) {
+			cleanupPoisonedTarget(t, target)
+		} else if active {
+			patch.Unpatch()
+		}
+	}()
+
+	panicked, recovered := catchPanicState(func() {
+		patch.unpatch(
+			func(target uintptr, replacement, _ []byte) (mem.ReplaceState, error) {
+				mem.WriteWithSTW(target, replacement)
+				panic(nil)
+			},
+			func(code []byte) {
+				releases++
+				inst.ReleaseProxy(code)
+			},
+		)
+		active = false
+	})
+
+	if !panicked {
+		t.Fatal("panic(nil) during Unpatch was treated as ReplaceApplied")
+	}
+	if recovered != nil {
+		t.Fatalf("recovered panic value = %#v, want nil", recovered)
+	}
+	if releases != 0 {
+		t.Fatalf("proxy releases = %d, want 0", releases)
+	}
+
+	patchRegistry.Lock()
+	failed := patchRegistry.failedByTarget[target]
+	stack := patchRegistry.byTarget[target]
+	patchRegistry.Unlock()
+	if failed == nil || failed.patch != patch {
+		t.Fatal("panic(nil) during Unpatch was not quarantined")
+	}
+	if failed.cause != nil {
+		t.Fatalf("quarantine cause = %#v, want nil", failed.cause)
+	}
+	if len(stack) == 0 || stack[len(stack)-1] != patch {
+		t.Fatal("panic(nil) during Unpatch popped the active patch")
+	}
+	if proxy == nil || proxy("value") != "value" {
+		t.Fatal("panic(nil) during Unpatch released or reset the proxy")
+	}
+	if got := LifecycleTarget("value"); got != "value" {
+		t.Fatalf("fake Unpatch returned %q, want original", got)
+	}
+
+	secondPanicked, _ := catchPanicState(patch.Unpatch)
+	if !secondPanicked {
+		t.Fatal("quarantined patch allowed another Unpatch")
+	}
+
+	cleanupPoisonedTarget(t, target)
+	active = false
+	cleaned = true
+	if proxy != nil {
+		t.Fatal("cleanup did not restore the nil proxy")
+	}
 }

--- a/internal/monkey/sysmon/suspend_1_23_riscv64.s
+++ b/internal/monkey/sysmon/suspend_1_23_riscv64.s
@@ -1,0 +1,27 @@
+//go:build !mockey_disable_ss && go1.23 && !go1.27
+// +build !mockey_disable_ss,go1.23,!go1.27
+
+/*
+ * Copyright 2022 ByteDance Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "textflag.h"
+
+TEXT ·usleepTrampoline(SB),NOSPLIT,$8
+	MOVWU	usec+0(FP), A0
+	MOV	pc+8(FP), T0
+	MOVW	A0, usec-8(SP)
+	JALR	RA, T0
+	RET

--- a/internal/tool/check_gcflags_amd64.go
+++ b/internal/tool/check_gcflags_amd64.go
@@ -31,11 +31,7 @@ func fn2() {
 }
 
 func IsGCFlagsSet() bool {
-	var asm []byte
-	header := (*reflect.SliceHeader)(unsafe.Pointer(&asm))
-	header.Data = reflect.ValueOf(fn2).Pointer()
-	header.Len = 1000
-	header.Cap = 1000
+	asm := unsafe.Slice((*byte)(unsafe.Pointer(reflect.ValueOf(fn2).Pointer())), 1000)
 
 	flag := false
 	pos := 0

--- a/internal/tool/check_gcflags_arm64.go
+++ b/internal/tool/check_gcflags_arm64.go
@@ -31,11 +31,7 @@ func fn2() {
 }
 
 func IsGCFlagsSet() bool {
-	var asm []byte
-	header := (*reflect.SliceHeader)(unsafe.Pointer(&asm))
-	header.Data = reflect.ValueOf(fn2).Pointer()
-	header.Len = 1000
-	header.Cap = 1000
+	asm := unsafe.Slice((*byte)(unsafe.Pointer(reflect.ValueOf(fn2).Pointer())), 1000)
 
 	flag := false
 	pos := 0

--- a/internal/tool/check_gcflags_riscv64.go
+++ b/internal/tool/check_gcflags_riscv64.go
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2022 ByteDance Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package tool
+
+import (
+	"runtime/debug"
+	"strings"
+)
+
+func IsGCFlagsSet() bool {
+	info, ok := debug.ReadBuildInfo()
+	if !ok {
+		return false
+	}
+	for _, setting := range info.Settings {
+		if setting.Key == "-gcflags" {
+			return hasRequiredGCFlags(setting.Value)
+		}
+	}
+	return false
+}
+
+func hasRequiredGCFlags(value string) bool {
+	var (
+		allPackages bool
+		noOptimize  bool
+		noInline    bool
+	)
+	for _, field := range strings.Fields(value) {
+		if pattern, flags, ok := strings.Cut(field, "="); ok {
+			allPackages = pattern == "all"
+			if !allPackages {
+				continue
+			}
+			field = flags
+		} else if !allPackages {
+			continue
+		}
+
+		switch field {
+		case "-N":
+			noOptimize = true
+		case "-l":
+			noInline = true
+		}
+	}
+	return noOptimize && noInline
+}

--- a/internal/tool/check_gcflags_riscv64_test.go
+++ b/internal/tool/check_gcflags_riscv64_test.go
@@ -1,0 +1,46 @@
+//go:build riscv64
+// +build riscv64
+
+/*
+ * Copyright 2022 ByteDance Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package tool
+
+import "testing"
+
+func TestHasRequiredGCFlags(t *testing.T) {
+	tests := []struct {
+		name  string
+		value string
+		want  bool
+	}{
+		{name: "required order", value: "all=-N -l", want: true},
+		{name: "reverse order", value: "all=-l -N", want: true},
+		{name: "split assignments", value: "all=-N all=-l", want: true},
+		{name: "missing no optimize", value: "all=-l", want: false},
+		{name: "missing no inline", value: "all=-N", want: false},
+		{name: "wrong package pattern", value: "github.com/acme/project=-N -l", want: false},
+		{name: "mixed package patterns", value: "all=-N github.com/acme/project=-l", want: false},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := hasRequiredGCFlags(test.value); got != test.want {
+				t.Fatalf("hasRequiredGCFlags(%q): got %v, want %v", test.value, got, test.want)
+			}
+		})
+	}
+}

--- a/internal/tool/goroutine_riscv64.s
+++ b/internal/tool/goroutine_riscv64.s
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2022 ByteDance Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "textflag.h"
+
+TEXT ·getG(SB), NOSPLIT, $0
+	MOV	g, ret+0(FP)
+	RET

--- a/licenses/LICENSE-arch.txt
+++ b/licenses/LICENSE-arch.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2015 The Go Authors. All rights reserved.
+Copyright 2015 The Go Authors.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are
@@ -10,7 +10,7 @@ notice, this list of conditions and the following disclaimer.
 copyright notice, this list of conditions and the following disclaimer
 in the documentation and/or other materials provided with the
 distribution.
-   * Neither the name of Google Inc. nor the names of its
+   * Neither the name of Google LLC nor the names of its
 contributors may be used to endorse or promote products derived from
 this software without specific prior written permission.
 

--- a/mock.go
+++ b/mock.go
@@ -41,6 +41,7 @@ type Mocker struct {
 	times     int64
 	mockTimes int64
 	patch     *monkey.Patch
+	patchKey  uintptr
 	lock      sync.Mutex
 	isPatched bool
 	builder   *MockBuilder
@@ -199,9 +200,33 @@ func (builder *MockBuilder) FilterGoRoutine(filter FilterGoroutineType, gId int6
 }
 
 func (builder *MockBuilder) Build() *Mocker {
+	mockLifecycleMu.Lock()
+	defer mockLifecycleMu.Unlock()
+
 	mocker := Mocker{builder: builder}
+	mocker.target = reflect.ValueOf(builder.target)
+	mocker.patchKey = builder.analyzer.RuntimeTargetValue().Pointer()
+	assertNotInGlobal(&mocker)
+
+	var origin, previousOrigin reflect.Value
+	if builder.originPtr != nil {
+		origin = reflect.ValueOf(builder.originPtr).Elem()
+		if origin.IsValid() {
+			previousOrigin = reflect.New(origin.Type()).Elem()
+			previousOrigin.Set(origin)
+		}
+	}
+	complete := false
+	defer func() {
+		if complete || !origin.IsValid() || mocker.patch != nil || monkey.IsPatchTargetPoisoned(mocker.patchKey) {
+			return
+		}
+		origin.Set(previousOrigin)
+	}()
+
 	mocker.build()
-	mocker.Patch()
+	mocker.patchLocked()
+	complete = true
 	return &mocker
 }
 
@@ -296,37 +321,54 @@ func (mocker *Mocker) build() {
 }
 
 func (mocker *Mocker) Patch() *Mocker {
+	mockLifecycleMu.Lock()
+	defer mockLifecycleMu.Unlock()
+	return mocker.patchLocked()
+}
+
+func (mocker *Mocker) patchLocked() *Mocker {
 	mocker.lock.Lock()
 	defer mocker.lock.Unlock()
 	if mocker.isPatched {
 		return mocker
 	}
+
 	runtimeTarget := mocker.builder.analyzer.RuntimeTargetValue()
+	mocker.patchKey = runtimeTarget.Pointer()
+	assertNotInGlobal(mocker)
 	mocker.patch = monkey.PatchValue(runtimeTarget, mocker.hook, mocker.proxy, mocker.builder.unsafe)
 	mocker.isPatched = true
 	addToGlobal(mocker)
-
 	mocker.outerCaller = tool.OuterCaller()
 	return mocker
 }
 
 func (mocker *Mocker) UnPatch() *Mocker {
+	mockLifecycleMu.Lock()
+	defer mockLifecycleMu.Unlock()
+	mocker.unPatchLocked()
+	return mocker
+}
+
+func (mocker *Mocker) unPatchLocked() {
 	mocker.lock.Lock()
 	defer mocker.lock.Unlock()
 	if !mocker.isPatched {
-		return mocker
+		return
 	}
+
+	assertTopInGlobal(mocker)
 	mocker.patch.Unpatch()
 	mocker.isPatched = false
 	removeFromGlobal(mocker)
 	atomic.StoreInt64(&mocker.times, 0)
 	atomic.StoreInt64(&mocker.mockTimes, 0)
-
-	return mocker
 }
 
 func (mocker *Mocker) Release() *MockBuilder {
-	mocker.UnPatch()
+	mockLifecycleMu.Lock()
+	defer mockLifecycleMu.Unlock()
+	mocker.unPatchLocked()
 	mocker.builder.resetCondition()
 	return mocker.builder
 }
@@ -380,10 +422,12 @@ func (mocker *Mocker) Origin(funcPtr interface{}) *Mocker {
 }
 
 func (mocker *Mocker) rePatch(do func()) *Mocker {
-	mocker.UnPatch()
+	mockLifecycleMu.Lock()
+	defer mockLifecycleMu.Unlock()
+	mocker.unPatchLocked()
 	do()
 	mocker.build()
-	mocker.Patch()
+	mocker.patchLocked()
 	return mocker
 }
 
@@ -403,16 +447,16 @@ func (mocker *Mocker) MockTimes() int {
 	return int(atomic.LoadInt64(&mocker.mockTimes))
 }
 
-func (mocker *Mocker) key() uintptr {
+func (mocker *Mocker) identityKey() uintptr {
 	return mocker.target.Pointer()
+}
+
+func (mocker *Mocker) layerKey() uintptr {
+	return mocker.patchKey
 }
 
 func (mocker *Mocker) name() string {
 	return mocker.target.String()
-}
-
-func (mocker *Mocker) unPatch() {
-	mocker.UnPatch()
 }
 
 func (mocker *Mocker) caller() tool.CallerInfo {

--- a/mock_test.go
+++ b/mock_test.go
@@ -64,6 +64,37 @@ func VariantParam(a int, b ...int) (int, int) {
 
 func ShortFun() {}
 
+func TestBuildFailureRestoresOrigin(t *testing.T) {
+	UnPatchAll()
+	defer UnPatchAll()
+
+	calls := 0
+	origin := func() {
+		calls++
+	}
+
+	var buildPanic interface{}
+	func() {
+		defer func() { buildPanic = recover() }()
+		Mock(ShortFun).To(func() {}).Origin(&origin).Build()
+	}()
+	if buildPanic == nil {
+		t.Fatal("safe patch of ShortFun unexpectedly succeeded")
+	}
+
+	var originPanic interface{}
+	func() {
+		defer func() { originPanic = recover() }()
+		origin()
+	}()
+	if originPanic != nil {
+		t.Fatalf("Origin panicked after rejected build: %v", originPanic)
+	}
+	if calls != 1 {
+		t.Fatalf("restored Origin calls = %d, want 1", calls)
+	}
+}
+
 func TestNoConvey(t *testing.T) {
 	origin := Fun
 	mock := func(p string) string {

--- a/mock_var.go
+++ b/mock_var.go
@@ -24,9 +24,10 @@ import (
 )
 
 type mockerInstance interface {
-	key() uintptr
+	identityKey() uintptr
+	layerKey() uintptr
 	name() string
-	unPatch()
+	unPatchLocked()
 
 	caller() tool.CallerInfo
 }
@@ -45,14 +46,19 @@ type MockerVar struct {
 func MockValue(targetPtr interface{}) *MockerVar {
 	tool.AssertPtr(targetPtr)
 
+	target := reflect.ValueOf(targetPtr).Elem()
 	return &MockerVar{
-		target:     reflect.ValueOf(targetPtr).Elem(),
-		origin:     reflect.ValueOf(targetPtr).Elem().Interface(),
-		targetType: reflect.TypeOf(targetPtr).Elem(),
+		target:     target,
+		targetType: target.Type(),
 	}
 }
 
 func (mocker *MockerVar) To(value interface{}) *MockerVar {
+	mockLifecycleMu.Lock()
+	defer mockLifecycleMu.Unlock()
+	mocker.lock.Lock()
+	defer mocker.lock.Unlock()
+
 	var v reflect.Type
 
 	if value == nil {
@@ -64,43 +70,63 @@ func (mocker *MockerVar) To(value interface{}) *MockerVar {
 	}
 
 	tool.Assert(v.AssignableTo(mocker.targetType), "value type: %s not match target type: %s", v.Name(), mocker.targetType.Name())
-	mocker.Patch()
+	mocker.patchValueLocked()
 	return mocker
 }
 
 func (mocker *MockerVar) Patch() *MockerVar {
+	mockLifecycleMu.Lock()
+	defer mockLifecycleMu.Unlock()
 	mocker.lock.Lock()
 	defer mocker.lock.Unlock()
+	mocker.patchValueLocked()
+	return mocker
+}
 
-	if !mocker.isPatched {
-		mocker.target.Set(mocker.hook)
-		mocker.isPatched = true
-		addToGlobal(mocker)
-
-		mocker.outerCaller = tool.OuterCaller()
+func (mocker *MockerVar) patchValueLocked() {
+	if mocker.isPatched {
+		return
 	}
 
-	return mocker
+	assertNotInGlobal(mocker)
+	mocker.origin = mocker.target.Interface()
+	mocker.target.Set(mocker.hook)
+	mocker.isPatched = true
+	addToGlobal(mocker)
+	mocker.outerCaller = tool.OuterCaller()
 }
 
 func (mocker *MockerVar) UnPatch() *MockerVar {
-	mocker.lock.Lock()
-	defer mocker.lock.Unlock()
-	if mocker.isPatched {
-		mocker.isPatched = false
-		if mocker.origin == nil {
-			mocker.target.Set(reflect.Zero(mocker.targetType))
-		} else {
-			mocker.target.Set(reflect.ValueOf(mocker.origin))
-		}
-		removeFromGlobal(mocker)
-	}
-
+	mockLifecycleMu.Lock()
+	defer mockLifecycleMu.Unlock()
+	mocker.unPatchLocked()
 	return mocker
 }
 
-func (mocker *MockerVar) key() uintptr {
+func (mocker *MockerVar) unPatchLocked() {
+	mocker.lock.Lock()
+	defer mocker.lock.Unlock()
+	if !mocker.isPatched {
+		return
+	}
+
+	assertTopInGlobal(mocker)
+	if mocker.origin == nil {
+		mocker.target.Set(reflect.Zero(mocker.targetType))
+	} else {
+		mocker.target.Set(reflect.ValueOf(mocker.origin))
+	}
+	mocker.isPatched = false
+	removeFromGlobal(mocker)
+	mocker.origin = nil
+}
+
+func (mocker *MockerVar) identityKey() uintptr {
 	return mocker.target.Addr().Pointer()
+}
+
+func (mocker *MockerVar) layerKey() uintptr {
+	return mocker.identityKey()
 }
 
 func (mocker *MockerVar) name() string {
@@ -108,10 +134,6 @@ func (mocker *MockerVar) name() string {
 		return "<string Value>"
 	}
 	return mocker.target.String()
-}
-
-func (mocker *MockerVar) unPatch() {
-	mocker.UnPatch()
 }
 
 func (mocker *MockerVar) caller() tool.CallerInfo {

--- a/mock_var_test.go
+++ b/mock_var_test.go
@@ -99,3 +99,233 @@ func TestVarStruct2(t *testing.T) {
 		So(ttt, ShouldBeNil)
 	})
 }
+
+func TestDuplicateMockValueDoesNotMutateTarget(t *testing.T) {
+	value := 1
+	PatchRun(func() {
+		first := MockValue(&value).To(2)
+
+		var recovered interface{}
+		func() {
+			defer func() { recovered = recover() }()
+			MockValue(&value).To(3)
+		}()
+		if recovered == nil {
+			t.Fatal("duplicate MockValue did not panic")
+		}
+		if value != 2 {
+			t.Fatalf("value after rejected duplicate = %d, want 2", value)
+		}
+		first.UnPatch()
+		if value != 1 {
+			t.Fatalf("value after unpatch = %d, want 1", value)
+		}
+	})
+	if value != 1 {
+		t.Fatalf("value after PatchRun = %d, want 1", value)
+	}
+}
+
+func TestNestedMockValueLayersRequireLIFO(t *testing.T) {
+	value := 1
+	PatchRun(func() {
+		outer := MockValue(&value).To(2)
+		if value != 2 {
+			t.Fatalf("outer value = %d, want 2", value)
+		}
+		PatchRun(func() {
+			MockValue(&value).To(3)
+			if value != 3 {
+				t.Fatalf("inner value = %d, want 3", value)
+			}
+
+			var recovered interface{}
+			func() {
+				defer func() { recovered = recover() }()
+				outer.UnPatch()
+			}()
+			if recovered == nil {
+				t.Fatal("out-of-order UnPatch did not panic")
+			}
+			if value != 3 {
+				t.Fatalf("value after rejected UnPatch = %d, want 3", value)
+			}
+		})
+		if value != 2 {
+			t.Fatalf("value after inner cleanup = %d, want 2", value)
+		}
+	})
+	if value != 1 {
+		t.Fatalf("value after outer cleanup = %d, want 1", value)
+	}
+}
+
+func TestRootMockValueCanBeLayeredByContext(t *testing.T) {
+	UnPatchAll()
+	defer UnPatchAll()
+
+	value := 1
+	root := MockValue(&value).To(2)
+	if value != 2 {
+		t.Fatalf("root value = %d, want 2", value)
+	}
+
+	PatchRun(func() {
+		MockValue(&value).To(3)
+		if value != 3 {
+			t.Fatalf("nested value = %d, want 3", value)
+		}
+	})
+	if value != 2 {
+		t.Fatalf("value after nested cleanup = %d, want 2", value)
+	}
+	root.UnPatch()
+	if value != 1 {
+		t.Fatalf("value after root unpatch = %d, want 1", value)
+	}
+}
+
+func TestPrecreatedMockValueCapturesInstalledLayer(t *testing.T) {
+	value := 1
+	inner := MockValue(&value)
+
+	PatchRun(func() {
+		outer := MockValue(&value).To(2)
+		if value != 2 {
+			t.Fatalf("outer value = %d, want 2", value)
+		}
+
+		PatchRun(func() {
+			inner.To(3)
+			if value != 3 {
+				t.Fatalf("inner value = %d, want 3", value)
+			}
+		})
+		if value != 2 {
+			t.Fatalf("value after inner cleanup = %d, want 2", value)
+		}
+		outer.UnPatch()
+		if value != 1 {
+			t.Fatalf("value after outer unpatch = %d, want 1", value)
+		}
+	})
+	if value != 1 {
+		t.Fatalf("value after PatchRun = %d, want 1", value)
+	}
+}
+
+func TestMockValueCanBeReused(t *testing.T) {
+	value := 1
+	mocker := MockValue(&value)
+
+	PatchRun(func() {
+		mocker.To(2)
+		if value != 2 {
+			t.Fatalf("first patched value = %d, want 2", value)
+		}
+		mocker.UnPatch()
+		if value != 1 {
+			t.Fatalf("value after first unpatch = %d, want 1", value)
+		}
+
+		value = 5
+		mocker.To(6)
+		if value != 6 {
+			t.Fatalf("second patched value = %d, want 6", value)
+		}
+		mocker.UnPatch()
+		if value != 5 {
+			t.Fatalf("value after second unpatch = %d, want 5", value)
+		}
+	})
+	if value != 5 {
+		t.Fatalf("value after PatchRun = %d, want 5", value)
+	}
+}
+
+func TestConcurrentScopesRejectSameTarget(t *testing.T) {
+	value := 1
+
+	outerReady := make(chan struct{})
+	releaseOuter := make(chan struct{})
+	outerDone := make(chan interface{}, 1)
+	go runBlockedPatchScope(&value, 2, outerReady, releaseOuter, outerDone)
+	<-outerReady
+
+	rejected := make(chan interface{}, 1)
+	go func() {
+		var recovered interface{}
+		func() {
+			defer func() { recovered = recover() }()
+			PatchRun(func() {
+				MockValue(&value).To(3)
+			})
+		}()
+		rejected <- recovered
+	}()
+	patchPanic := <-rejected
+	afterRejected := value
+
+	close(releaseOuter)
+	outerPanic := <-outerDone
+
+	if patchPanic == nil {
+		t.Fatal("same-target patch from a concurrent scope owner did not panic")
+	}
+	if afterRejected != 2 {
+		t.Fatalf("value after rejected concurrent patch = %d, want 2", afterRejected)
+	}
+	if outerPanic != nil {
+		t.Fatalf("outer scope cleanup panicked: %v", outerPanic)
+	}
+	if value != 1 {
+		t.Fatalf("value after outer scope cleanup = %d, want 1", value)
+	}
+}
+
+func TestConcurrentRootMockValueHasSingleWinner(t *testing.T) {
+	UnPatchAll()
+	defer UnPatchAll()
+
+	const workers = 8
+	value := 0
+	mockers := make([]*MockerVar, workers)
+	for i := range mockers {
+		mockers[i] = MockValue(&value)
+	}
+
+	start := make(chan struct{})
+	results := make(chan int, workers)
+	for i, mocker := range mockers {
+		go func(value int, mocker *MockerVar) {
+			<-start
+			defer func() {
+				if recover() != nil {
+					results <- 0
+				}
+			}()
+			mocker.To(value)
+			results <- value
+		}(i+1, mocker)
+	}
+
+	close(start)
+	winner := 0
+	successCount := 0
+	for range workers {
+		if result := <-results; result != 0 {
+			successCount++
+			winner = result
+		}
+	}
+	if successCount != 1 {
+		t.Fatalf("successful MockValue calls = %d, want 1", successCount)
+	}
+	if value != winner {
+		t.Fatalf("patched value = %d, want winner %d", value, winner)
+	}
+	UnPatchAll()
+	if value != 0 {
+		t.Fatalf("value after cleanup = %d, want 0", value)
+	}
+}

--- a/utils.go
+++ b/utils.go
@@ -91,7 +91,7 @@ func getMethod(val reflect.Value, methodName string, opts *methodOption) (method
 	}
 
 	// check ptr type for exported or unexported method
-	ptrType := reflect.PtrTo(typ)
+	ptrType := reflect.PointerTo(typ)
 	if m, ok := ptrType.MethodByName(methodName); ok {
 		return m.Func, true
 	}
@@ -177,7 +177,7 @@ func getNestedMethod(val reflect.Value, methodName string) (reflect.Method, bool
 	if m, ok := typ.MethodByName(methodName); ok {
 		return m, true
 	}
-	return reflect.PtrTo(typ).MethodByName(methodName)
+	return reflect.PointerTo(typ).MethodByName(methodName)
 }
 
 // unexportedMethodByName resolve an unexported method from an instance


### PR DESCRIPTION
#### What type of PR is this?

feat

#### What this PR does / why we need it (en: English/zh: Chinese):

en:
Add Linux/RISC-V64 support, including RVA20, RVA22, and RVA23 instruction handling, function relocation, runtime integration, and support for systems using 64 KiB pages.

Linux/RISC-V64 requires Go 1.26 or later. The minimum Go version for other supported architectures is raised to Go 1.24 because `golang.org/x/arch` is upgraded to v0.23.0.

zh:
新增 Linux/RISC-V64 支持，包括 RVA20、RVA22 和 RVA23 指令处理、函数重定位、运行时集成，以及对 64 KiB 页系统的支持。

Linux/RISC-V64 需要 Go 1.26 或更高版本。由于 `golang.org/x/arch` 升级至 v0.23.0，其他已支持架构的最低 Go 版本提升至 Go 1.24。

#### Which issue(s) this PR fixes:

N/A