### PR TITLE
fix: UnPatchAll should delete entries from map

### DIFF
--- a/global.go
+++ b/global.go
@@ -166,7 +166,8 @@ func PatchRun(f func()) {
 //		}
 //	}
 func UnPatchAll() {
-	for _, mocker := range gMocker[len(gMocker)-1] {
+	for key, mocker := range gMocker[len(gMocker)-1] {
 		mocker.unPatch()
+		delete(gMocker[len(gMocker)-1], key)
 	}
 }


### PR DESCRIPTION
## Problem

`UnPatchAll()` in `global.go` calls `mocker.unPatch()` for all mockers in the current context but doesn't delete the entries from the `gMocker` map.

## Impact

After calling `UnPatchAll()`, the map still contains stale entries. If `Mock()` is called again within the same context, `addToGlobal()` will detect the key already exists and trigger the assertion:

```go
tool.Assert(!ok, "re-mock %v, previous mock at: %v", last.name(), last.caller())
```

This causes false "re-mock" errors even though the previous mock was properly unpatched.

## Fix

Delete entries from the map after unpatching to keep the registry clean.

Closes #124

Local environment limitations, relying on CI/CD automated testing.
