### PR TITLE
feat(v1.2.x): make short functions patchable without -gcflags=all=-N (backport of #126)

### DIFF
--- a/internal/monkey/common/page.go
+++ b/internal/monkey/common/page.go
@@ -38,6 +38,17 @@ func AllocatePage() []byte {
 	return page
 }
 
+func AllocatePageNear(target uintptr) ([]byte, error) {
+	return allocateNear(target, int(pageSize))
+}
+
+func Rel32Reachable(from, to uintptr) bool {
+	if to >= from {
+		return to-from <= 1<<31-1
+	}
+	return from-to <= 1<<31
+}
+
 func ReleasePage(mem []byte) {
 	err := free(mem)
 	tool.Assert(err == nil, "free page failed: %v", err)

--- a/internal/monkey/common/page_alloc.go
+++ b/internal/monkey/common/page_alloc.go
@@ -20,13 +20,128 @@
 package common
 
 import (
+	"fmt"
+	"runtime"
 	"syscall"
 )
 
 func allocate(n int) ([]byte, error) {
-	return syscall.Mmap(-1, 0, int(n), syscall.PROT_READ|syscall.PROT_WRITE, syscall.MAP_ANON|syscall.MAP_PRIVATE)
+	return mmap(0, n, 0)
+}
+
+func allocateNear(target uintptr, n int) ([]byte, error) {
+	if runtime.GOOS == "linux" {
+		if page, supported := allocateNearLinux(target, n); page != nil || supported {
+			if page != nil {
+				return page, nil
+			}
+			return nil, fmt.Errorf("no free page within rel32 range of 0x%x", target)
+		}
+	}
+	return allocateNearWithHints(target, n)
+}
+
+func allocateNearLinux(target uintptr, n int) ([]byte, bool) {
+	const (
+		mapFixedNoReplace = 0x100000
+		searchStep        = uintptr(64 << 10)
+		maxDistance       = uintptr(1<<31 - 1)
+	)
+	supported := true
+	for offset := searchStep; offset+uintptr(n) < maxDistance; offset += searchStep {
+		for _, above := range []bool{true, false} {
+			hint, ok := nearHint(target, offset, above)
+			if !ok {
+				continue
+			}
+			page, err := mmap(hint, n, mapFixedNoReplace)
+			if err != nil {
+				if err == syscall.EINVAL {
+					supported = false
+					return nil, supported
+				}
+				continue
+			}
+			addr := PtrOf(page)
+			if addr != hint {
+				// Kernels older than MAP_FIXED_NOREPLACE may ignore the flag.
+				_ = free(page)
+				return nil, false
+			}
+			if Rel32Reachable(target+5, addr+uintptr(n-1)) {
+				return page, supported
+			}
+			_ = free(page)
+		}
+	}
+	return nil, supported
+}
+
+func allocateNearWithHints(target uintptr, n int) ([]byte, error) {
+	const (
+		megabyte = uintptr(1 << 20)
+		gigabyte = uintptr(1 << 30)
+	)
+	offsets := [...]uintptr{
+		megabyte, 16 * megabyte, 64 * megabyte, 256 * megabyte,
+		512 * megabyte, gigabyte, gigabyte + 512*megabyte,
+	}
+	for _, offset := range offsets {
+		for _, above := range []bool{true, false} {
+			hint, ok := nearHint(target, offset, above)
+			if !ok {
+				continue
+			}
+			page, err := mmap(hint, n, 0)
+			if err != nil {
+				continue
+			}
+			addr := PtrOf(page)
+			if Rel32Reachable(target+5, addr) && Rel32Reachable(target+5, addr+uintptr(n-1)) {
+				return page, nil
+			}
+			_ = free(page)
+		}
+	}
+	return nil, fmt.Errorf("no free page within rel32 range of 0x%x", target)
+}
+
+func nearHint(target, offset uintptr, above bool) (uintptr, bool) {
+	var hint uintptr
+	if above {
+		hint = target + offset
+		if hint < target {
+			return 0, false
+		}
+	} else {
+		if offset > target {
+			return 0, false
+		}
+		hint = target - offset
+	}
+	return PageOf(hint), true
 }
 
 func free(b []byte) error {
-	return syscall.Munmap(b)
+	_, _, errno := syscall.Syscall(syscall.SYS_MUNMAP, PtrOf(b), uintptr(len(b)), 0)
+	if errno != 0 {
+		return errno
+	}
+	return nil
+}
+
+func mmap(hint uintptr, n int, extraFlags uintptr) ([]byte, error) {
+	addr, _, errno := syscall.Syscall6(
+		syscall.SYS_MMAP,
+		hint,
+		uintptr(n),
+		syscall.PROT_READ|syscall.PROT_WRITE,
+		syscall.MAP_ANON|syscall.MAP_PRIVATE|extraFlags,
+		^uintptr(0),
+		0,
+	)
+	if errno != 0 {
+		return nil, errno
+	}
+	return BytesOf(addr, n), nil
 }

--- a/internal/monkey/common/page_alloc_windows.go
+++ b/internal/monkey/common/page_alloc_windows.go
@@ -54,6 +54,46 @@ func allocate(n int) ([]byte, error) {
 	return BytesOf(ptr, n), nil
 }
 
+func allocateNear(target uintptr, n int) ([]byte, error) {
+	const allocationGranularity = uintptr(64 << 10)
+	offsets := [...]uintptr{1 << 20, 16 << 20, 64 << 20, 256 << 20, 512 << 20, 1 << 30, 1536 << 20}
+	for _, offset := range offsets {
+		for _, above := range []bool{true, false} {
+			hint, ok := nearHintWindows(target, offset, above)
+			if !ok {
+				continue
+			}
+			hint &^= allocationGranularity - 1
+			ptr, _, _ := virtualAlloc.Call(
+				hint,
+				uintptr(n),
+				_MEM_COMMIT|_MEM_RESERVE,
+				_PAGE_READWRITE,
+			)
+			if ptr == 0 {
+				continue
+			}
+			page := BytesOf(ptr, n)
+			if Rel32Reachable(target+5, ptr) && Rel32Reachable(target+5, ptr+uintptr(n-1)) {
+				return page, nil
+			}
+			_ = free(page)
+		}
+	}
+	return nil, fmt.Errorf("no free page within rel32 range of 0x%x", target)
+}
+
+func nearHintWindows(target, offset uintptr, above bool) (uintptr, bool) {
+	if above {
+		hint := target + offset
+		return hint, hint >= target
+	}
+	if offset > target {
+		return 0, false
+	}
+	return target - offset, true
+}
+
 func free(b []byte) error {
 	res, _, err := virtualFree.Call(
 		PtrOf(b),

--- a/internal/monkey/common/page_amd64_test.go
+++ b/internal/monkey/common/page_amd64_test.go
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2022 ByteDance Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package common
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestAllocatePageNear(t *testing.T) {
+	target := reflect.ValueOf(TestAllocatePageNear).Pointer()
+	page, err := AllocatePageNear(target)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ReleasePage(page)
+
+	start := PtrOf(page)
+	if !Rel32Reachable(target+5, start) || !Rel32Reachable(target+5, start+uintptr(len(page)-1)) {
+		t.Fatalf("page [0x%x, 0x%x] is outside rel32 range of 0x%x", start, start+uintptr(len(page)-1), target)
+	}
+	page[0] = 1
+	page[len(page)-1] = 2
+}

--- a/internal/monkey/diagnostic_test.go
+++ b/internal/monkey/diagnostic_test.go
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2022 ByteDance Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package monkey
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+//go:noinline
+func diagnosticTarget() int { return 3 }
+
+// A refusal to patch must name the target and quote what was read there.
+//
+// This is not decoration. "unrecognized instruction" on its own is the one
+// mockey failure that can be caused by an *earlier* mock rather than by the
+// call site in the stack trace, so without an address there is nothing to
+// correlate against and diagnosis means bisecting test order by hand. That is
+// exactly what happened in the report this test comes from.
+func TestPatchRefusalNamesTheTarget(t *testing.T) {
+	addr := reflect.ValueOf(diagnosticTarget).Pointer()
+
+	// A deliberately mangled entry: an E9 whose tail is 0x37 (AAA, which does
+	// not exist in 64-bit mode). Fed to the same helper PatchValue uses, so the
+	// message under test is the real one.
+	mangled := []byte{0xe9, 0x11, 0x22, 0x33, 0x44, 0x37, 0x55, 0x48, 0x89, 0xe5}
+
+	var got string
+	func() {
+		defer func() {
+			if r := recover(); r != nil {
+				got = fmt.Sprint(r)
+			}
+		}()
+		disassembleOrExplain(addr, mangled, 12, false)
+	}()
+
+	if got == "" {
+		t.Skip("this entry decodes on this architecture; nothing to report here")
+	}
+	for _, want := range []string{
+		"diagnosticTarget",        // which function
+		fmt.Sprintf("0x%x", addr), // the address, matching the MOCKEY_DEBUG ledger
+		"e9 11 22 33 44 37",       // the bytes actually read
+		"already patched",         // the likely cause, stated
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("refusal does not mention %q; message was:\n%s", want, got)
+		}
+	}
+}
+
+// The happy path must be untouched: a normal target still yields a cutting
+// point, not a diagnostic.
+func TestPatchRefusalSilentOnSuccess(t *testing.T) {
+	var proxy func() int
+	p := PatchFunc(diagnosticTarget, func() int { return 4 }, &proxy, false)
+	defer p.Unpatch()
+	if got := diagnosticTarget(); got != 4 {
+		t.Fatalf("patch not effective: %d", got)
+	}
+}

--- a/internal/monkey/entry_padding_amd64_test.go
+++ b/internal/monkey/entry_padding_amd64_test.go
@@ -1,0 +1,332 @@
+//go:build amd64 && !windows
+// +build amd64,!windows
+
+/*
+ * Copyright 2022 ByteDance Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package monkey
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/bytedance/mockey/internal/monkey/common"
+	"github.com/bytedance/mockey/internal/monkey/inst"
+)
+
+var orphanGlobal = 41
+
+// orphanEntryTarget is shaped to produce the failing case rather than merely a
+// short-branch one, and both halves of that matter:
+//
+//   - the RIP-relative read of orphanGlobal makes the legacy twelve-byte prefix
+//     unrelocatable, so PatchValue falls through to the short branch;
+//   - the entry begins CMP(4) + Jcc(2), so the cut rounds up to 6 while the E9
+//     is only 5 wide. That one leftover byte is the orphan.
+//
+// A target whose cut happens to land exactly on 5 takes the short branch too,
+// but leaves nothing behind and so cannot detect this bug at all.
+//
+//go:noinline
+func orphanEntryTarget(a int, p *int) int {
+	if a > 3 {
+		return orphanGlobal
+	}
+	return *p + a
+}
+
+// illegalOrphanTarget is orphanEntryTarget's sharper twin: same short-branch
+// shape, but its orphan byte does not decode.
+//
+// The distinction matters because it is the whole difference between a
+// regression test that fires and one that does not. orphanEntryTarget's cut
+// leaves 0x08 behind, and 0x08 happens to be a legal opcode (OR r/m8, r8), so
+// an unpadded entry there is still a decodable instruction stream and a later
+// Patch accepts it. The bug is present but invisible.
+//
+// Here the arithmetic chain in the taken branch pushes the Jcc displacement out
+// to 0x1e, which is not a legal opcode. An unpadded entry becomes exactly what
+// the wrapper failure was: an entry mockey can no longer read back, so the next
+// Patch on the same function dies in Disassemble with "unrecognized
+// instruction".
+//
+// The displacement is load-bearing and it is a property of the generated code,
+// not of the source. TestIllegalOrphanFixtureStillBites asserts it rather than
+// trusting it, so that a compiler change that moves the byte is reported as
+// such instead of silently retiring the test.
+//
+//go:noinline
+func illegalOrphanTarget(a int, p *int) int {
+	if a > 3 {
+		s := orphanGlobal
+		s = s*3 + orphanGlobal2*1
+		s = s*3 + orphanGlobal2*2
+		return s
+	}
+	return *p + a + orphanGlobal2
+}
+
+var orphanGlobal2 = 7
+
+//go:noinline
+func orphanEntryLegacyTarget(a, b, c int) int {
+	s := a*3 + b*5 + c*7
+	for i := 0; i < 3; i++ {
+		s += i * a
+	}
+	return s
+}
+
+// decodable reports whether a later Patch would accept this entry.
+func decodable(code []byte, required int, checkLen bool) bool {
+	_, ok := inst.TryDisassemble(code, required, checkLen)
+	return ok
+}
+
+// entryOf reads back what is actually in the target's first bytes right now.
+func entryOf(f interface{}, n int) []byte {
+	return common.BytesOf(reflect.ValueOf(f).Pointer(), n)
+}
+
+// TestPatchedEntryStaysDecodable is the regression test for a cross-test mock
+// leak seen on a real repository, which surfaced as a bare
+// "unrecognized instruction" panic naming neither address nor cause.
+//
+// A patched entry must remain a valid instruction stream, because mockey reads
+// its own patched code back: every later Patch of the same function
+// disassembles the live entry to find a cutting point. The cutting point is
+// rounded up to an instruction boundary and is therefore often wider than the
+// branch written over it -- a five-byte E9 over a six-byte CMP/JBE prologue is
+// the common case -- so any byte of the cut left unwritten is the tail of an
+// instruction whose head is gone. The CPU never reaches it, so the patch works;
+// the disassembler does, and chokes.
+//
+// This only needs one mock to still be live when the next is built, which is
+// what a Mock(...) at the top level of a test function always leaves behind.
+func TestPatchedEntryStaysDecodable(t *testing.T) {
+	var proxy func(int, *int) int
+	branchWidth := len(inst.BranchInto(0))
+	// Capture how the pristine entry answers, before patching anything.
+	cleanMock := decodable(entryOf(orphanEntryTarget, 64), branchWidth, true)
+	cleanUnsafe := decodable(entryOf(orphanEntryTarget, 64), branchWidth, false)
+
+	p := PatchFunc(orphanEntryTarget, func(int, *int) int { return -1 }, &proxy, false)
+	defer p.Unpatch()
+	if !p.shortBranch {
+		t.Skip("target was not patched via the short branch; nothing to pin here")
+	}
+
+	cuttingIdx := len(p.original)
+	live := entryOf(orphanEntryTarget, 64)
+
+	// Every byte of the cut must have been written: nothing of the original
+	// instruction stream may survive inside it.
+	if got := live[:inst.ShortBranchSize()]; got[0] != 0xe9 {
+		t.Fatalf("entry does not start with E9: % x", got)
+	}
+	for i := inst.ShortBranchSize(); i < cuttingIdx; i++ {
+		if live[i] == p.original[i] {
+			t.Fatalf("byte %d of the cut still holds the original 0x%02x: an orphan "+
+				"instruction tail, entry = % x", i, live[i], live[:cuttingIdx])
+		}
+	}
+
+	// The property that actually matters: patching must not make the entry any
+	// less decodable than it already was.
+	//
+	// Note this is deliberately a comparison, not an absolute assertion. A
+	// target that took the short branch is frequently one the legacy path had
+	// already refused ("function is too short to patch"), and that refusal is a
+	// legitimate answer about the target's own shape, not damage we did. The
+	// bug being pinned here is the other kind of failure: a well-formed entry
+	// turning into an undecodable one because we wrote over it.
+	if got := decodable(live, branchWidth, true); got != cleanMock {
+		t.Fatalf("patching changed how a later Mock decodes the entry: clean=%v live=%v, entry = % x",
+			cleanMock, got, live[:16])
+	}
+	if got := decodable(live, branchWidth, false); got != cleanUnsafe {
+		t.Fatalf("patching changed how a later MockUnsafe decodes the entry: clean=%v live=%v, entry = % x",
+			cleanUnsafe, got, live[:16])
+	}
+}
+
+// TestRepatchWhileShortBranchIsLive is the end-to-end form: patch, leak the
+// patch (never unpatch it, as a top-level Mock does), then patch the same
+// function again. This is the exact sequence that panicked.
+func TestRepatchWhileShortBranchIsLive(t *testing.T) {
+	var proxy func(int, *int) int
+	first := PatchFunc(orphanEntryTarget, func(int, *int) int { return -1 }, &proxy, false)
+	defer first.Unpatch()
+	if !first.shortBranch {
+		t.Skip("target was not patched via the short branch; nothing to pin here")
+	}
+	if got := orphanEntryTarget(0, nil); got != -1 {
+		t.Fatalf("first patch is not effective: got %d, want -1", got)
+	}
+
+	// deliberately NOT unpatched, then re-patched -- both the safe and the
+	// unsafe way, since the report's crash came in through MockUnsafe.
+	var safeProxy func(int, *int) int
+	second := PatchFunc(orphanEntryTarget, func(int, *int) int { return -2 }, &safeProxy, false)
+	if got := orphanEntryTarget(0, nil); got != -2 {
+		t.Fatalf("re-patch over a live patch is not effective: got %d, want -2", got)
+	}
+	second.Unpatch()
+
+	var unsafeProxy func(int, *int) int
+	third := PatchFunc(orphanEntryTarget, func(int, *int) int { return -3 }, &unsafeProxy, true)
+	if got := orphanEntryTarget(0, nil); got != -3 {
+		t.Fatalf("unsafe re-patch over a live patch is not effective: got %d, want -3", got)
+	}
+	third.Unpatch()
+}
+
+// TestIllegalOrphanFixtureStillBites guards the guard.
+//
+// TestRepatchOverIllegalOrphanEntry can only fail for the right reason while
+// illegalOrphanTarget's orphan byte stays undecodable. That byte is chosen by
+// the compiler, so a toolchain change can quietly turn the test below into one
+// that passes whether or not the fix is present -- which is precisely the
+// failure this file exists to prevent, and precisely what happened to the
+// original fixture.
+//
+// So assert the premise separately. If this fails, the fixture needs a new
+// shape; the padding itself may well be fine.
+func TestIllegalOrphanFixtureStillBites(t *testing.T) {
+	short := inst.ShortBranchSize()
+	entry := entryOf(illegalOrphanTarget, 64)
+
+	cuttingIdx, ok := inst.TryDisassemble(entry, short, true)
+	if !ok {
+		t.Fatalf("fixture no longer takes the short branch: entry = % x", entry[:16])
+	}
+	if cuttingIdx <= short {
+		t.Fatalf("fixture leaves no orphan: cut=%d short=%d, entry = % x", cuttingIdx, short, entry[:16])
+	}
+
+	// Rebuild the entry the way an unpadded PatchValue would have left it: the
+	// five-byte E9 written in, the rest of the cut left untouched.
+	unpadded := make([]byte, len(entry))
+	copy(unpadded, entry)
+	unpadded[0] = 0xe9
+	for i := 1; i < short; i++ {
+		unpadded[i] = 0x11
+	}
+	if decodable(unpadded, len(inst.BranchInto(0)), false) {
+		t.Fatalf("orphan byte 0x%02x still decodes: this fixture cannot detect the bug "+
+			"it was written for, entry = % x", entry[short], entry[:16])
+	}
+}
+
+// TestRepatchOverIllegalOrphanEntry is the end-to-end reproduction: it goes
+// through PatchValue, not through a hand-built byte array, and it fails when
+// the padding is removed.
+//
+// The sequence is the one the wrapper hit. A mock is left live -- the ordinary
+// shape of a Mock(...) at the top of a test function -- and the next mock on
+// the same function has to read the patched entry back to find its own cutting
+// point. Without padding that read hits the orphan and Disassemble refuses.
+func TestRepatchOverIllegalOrphanEntry(t *testing.T) {
+	var proxy func(int, *int) int
+	first := PatchFunc(illegalOrphanTarget, func(int, *int) int { return -1 }, &proxy, false)
+	defer first.Unpatch()
+	if !first.shortBranch {
+		t.Skip("target was not patched via the short branch; nothing to pin here")
+	}
+
+	zero := 0
+	if got := illegalOrphanTarget(0, &zero); got != -1 {
+		t.Fatalf("first patch is not effective: got %d, want -1", got)
+	}
+
+	// The live patch is deliberately left in place. Re-patch through
+	// MockUnsafe, which is the path the wrapper crash came in through.
+	var unsafeProxy func(int, *int) int
+	second := PatchFunc(illegalOrphanTarget, func(int, *int) int { return -2 }, &unsafeProxy, true)
+	if got := illegalOrphanTarget(0, &zero); got != -2 {
+		t.Fatalf("re-patch over a live patch is not effective: got %d, want -2", got)
+	}
+	second.Unpatch()
+}
+
+func TestLegacyPatchedEntryStaysDecodable(t *testing.T) {
+	var proxy func(int, int, int) int
+	p := PatchFunc(orphanEntryLegacyTarget, func(int, int, int) int { return -1 }, &proxy, false)
+	defer p.Unpatch()
+	if p.shortBranch {
+		t.Skip("target took the short branch; this test is about the legacy one")
+	}
+
+	live := entryOf(orphanEntryLegacyTarget, 64)
+	for i := len(inst.BranchInto(0)); i < len(p.original); i++ {
+		if live[i] == p.original[i] {
+			t.Fatalf("byte %d of the legacy cut still holds the original 0x%02x: "+
+				"an orphan instruction tail, entry = % x", i, live[i], live[:len(p.original)])
+		}
+	}
+	if !decodable(live, len(inst.BranchInto(0)), false) {
+		t.Fatalf("live legacy entry is not decodable: % x", live[:16])
+	}
+}
+
+// TestOrphanTailIsTheWrapperSymptom pins the byte sequence that produced the
+// original report, so a future change that reintroduces the orphan tail is
+// recognisable as this bug rather than as a fresh mystery.
+//
+// These are the real first bytes of a stack-checked Go prologue whose body
+// reads a global:
+//
+//	49 3b 66 10   CMP RSP, [R14+0x10]
+//	76 37         JBE +0x37            <- cut lands at 6, branch is 5 wide
+//	55 48 89 e5   PUSH RBP; MOV RBP, RSP
+//	48 c7 05 ...  MOV [RIP+disp], imm  <- PC-relative: legacy path refused,
+//	                                      so the short branch is chosen
+//
+// Leaving the JBE's displacement byte 0x37 behind is not a harmless leftover:
+// 0x37 is AAA, which does not exist in 64-bit mode.
+func TestOrphanTailIsTheWrapperSymptom(t *testing.T) {
+	clean := []byte{
+		0x49, 0x3b, 0x66, 0x10,
+		0x76, 0x37,
+		0x55,
+		0x48, 0x89, 0xe5,
+		0x48, 0xc7, 0x05, 0x23, 0x67, 0x18, 0x00, 0x01, 0x00, 0x00, 0x00,
+		0x48, 0x89, 0xe5, 0x5d, 0xc3,
+	}
+	branchWidth := len(inst.BranchInto(0))
+
+	cut, ok := inst.TryDisassemble(clean, inst.ShortBranchSize(), true)
+	if !ok {
+		t.Fatal("fixture no longer takes the short branch")
+	}
+	if cut <= inst.ShortBranchSize() {
+		t.Fatalf("fixture no longer has an orphan tail: cut=%d", cut)
+	}
+
+	unpadded := append([]byte(nil), clean...)
+	copy(unpadded, []byte{0xe9, 0x11, 0x22, 0x33, 0x44})
+	if _, ok := inst.TryDisassemble(unpadded, branchWidth, false); ok {
+		t.Fatal("fixture no longer demonstrates the failure; it must stay a " +
+			"case where an unpadded entry is undecodable, or it pins nothing")
+	}
+
+	padded := inst.PadEntry([]byte{0xe9, 0x11, 0x22, 0x33, 0x44}, cut)
+	fixed := append([]byte(nil), clean...)
+	copy(fixed, padded)
+	if _, ok := inst.TryDisassemble(fixed, branchWidth, false); !ok {
+		t.Fatalf("padded entry is still undecodable: % x", fixed[:12])
+	}
+}

--- a/internal/monkey/inst/disasm.go
+++ b/internal/monkey/inst/disasm.go
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2022 ByteDance Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package inst
+
+// errFunctionTooShort is the refusal Disassemble has always panicked with when
+// a target ends before the branch sequence fits and the tail is not padding.
+// Kept as a constant so the panicking and error-returning paths cannot drift.
+const errFunctionTooShort = "function is too short to patch"
+
+// TryDisassemble finds the cutting point, reporting ok=false instead of
+// panicking when there is no usable one.
+//
+// It shares its implementation with Disassemble: both call disassemble, which
+// returns a refusal as an error. Probing therefore cannot miss a refusal reason
+// that gets added later, and -- unlike catching the panic -- a genuine bug in
+// the disassembler is not silently reported as "not patchable", because only an
+// explicitly returned error counts as a refusal here.
+func TryDisassemble(code []byte, required int, checkLen bool) (int, bool) {
+	pos, err := disassemble(code, required, checkLen)
+	return pos, err == nil
+}
+
+// DisassembleErr is TryDisassemble that hands back the refusal itself, for
+// callers that want to report why rather than merely whether. It exists so that
+// a caller can add context (which function, what bytes) to the reason without
+// having to restate the reason -- and therefore without being able to drift
+// from it.
+func DisassembleErr(code []byte, required int, checkLen bool) (int, error) {
+	return disassemble(code, required, checkLen)
+}

--- a/internal/monkey/inst/disasm_amd64.go
+++ b/internal/monkey/inst/disasm_amd64.go
@@ -17,6 +17,7 @@
 package inst
 
 import (
+	"errors"
 	"reflect"
 	"unsafe"
 
@@ -53,19 +54,107 @@ func calcFnAddrRange(name string, fn func()) (uintptr, uintptr) {
 	return 0, 0
 }
 
+// padByte is what the amd64 linker writes between functions.
+// See cmd/link/internal/amd64/obj.go: CodePad = []byte{0xCC} (INT $3),
+// emitted to pad each function entry up to funcAlign = 32
+// (cmd/link/internal/amd64/l.go).
+const padByte = 0xcc
+
+// Disassemble finds the cutting point, panicking when it cannot. This is the
+// long-standing entry point and its panic behaviour -- both when it fires and
+// what it carries -- is unchanged.
 func Disassemble(code []byte, required int, checkLen bool) int {
+	pos, err := disassemble(code, required, checkLen)
+	tool.Assert(err == nil, err)
+	return pos
+}
+
+// disassemble is the actual implementation. It reports refusals as an error
+// instead of panicking, so callers that are merely probing a cutting point can
+// ask without arranging to catch a panic.
+//
+// Returning an error rather than recovering in the caller matters for two
+// reasons. Refusal reasons can be added here later and no probing caller can
+// silently miss one, because there is nothing to keep in sync. And a genuine
+// bug in this function -- a slice overrun, a nil deref -- still panics and
+// still escapes, instead of being quietly reported as "this function is not
+// patchable"; only the errors returned below are treated as refusals.
+func disassemble(code []byte, required int, checkLen bool) (int, error) {
 	var pos int
 	var err error
 	var inst x86asm.Inst
 
 	for pos < required {
 		inst, err = x86asm.Decode(code[pos:], 64)
-		tool.Assert(err == nil, err)
+		if err != nil {
+			return 0, err
+		}
 		tool.DebugPrintf("Disassemble: inst: %v\n", inst)
-		tool.Assert(inst.Op != x86asm.RET || !checkLen, "function is too short to patch")
+		if inst.Op == x86asm.RET {
+			// The target's own code ends here, so it is shorter than the branch
+			// sequence we need to write. That is only fatal if the remaining bytes
+			// belong to the *next* function. On amd64 they do not: the linker aligns
+			// every function entry to 32 bytes and fills the gap with 0xCC, which is
+			// dead space no control flow ever enters. Overwriting it is harmless, so
+			// only refuse when the tail is not padding.
+			//
+			// Why we keep decoding instead of `return required` -- read this before
+			// "simplifying" it back:
+			//
+			// The value returned here is PatchValue's cuttingIdx, and it is used for
+			// three things at once (internal/monkey/patch.go):
+			//   1. the trampoline saves code[:cuttingIdx],
+			//   2. the trampoline ends with BranchTo(targetAddr+cuttingIdx),
+			//   3. Unpatch restores cuttingIdx bytes.
+			// (2) makes cuttingIdx a *jump target in the original instruction
+			// stream*, so it MUST sit on an instruction boundary; (1) means the
+			// saved prefix must end on one too, or the trampoline's last "instruction"
+			// is a truncated fragment. `required` is just the length of the branch
+			// sequence (12 bytes here) -- nothing makes it land on a boundary.
+			//
+			// The non-RET exit below returns `pos`, which is boundary-aligned by
+			// construction. The RET branch returning the raw `required` was the odd
+			// one out, and it is exactly the bug: for a frameless function with an
+			// early `return`, e.g.
+			//     @0 TEST(3) @3 JLE(2) @5 MOV(5) @10 RET(1) @11 IMUL(4) @15 ...
+			// the loop hits RET at pos=10 and returns 12 -- which is the *middle* of
+			// the 4-byte IMUL at [11,15). The trampoline then keeps only the orphan
+			// REX prefix 0x48 of that IMUL and jumps back into its middle, so the CPU
+			// executes a garbage instruction stream. Depending on how those bytes
+			// happen to decode you get a SIGSEGV or, worse, a silently wrong result.
+			//
+			// So instead of trusting `required`, walk whole instructions until we are
+			// at or past it, and return that boundary. The returned value is still
+			// >= required (never restoring/overwriting less than the branch sequence),
+			// it is just rounded up to the next boundary instead of cutting blindly.
+			//
+			// Note this changes nothing for the checkLen==true (Mock) path: there
+			// every skipped byte must be 0xCC padding, and INT3 is 1 byte long, so pos
+			// lands exactly on `required` anyway. Only the checkLen==false
+			// (MockUnsafe) path, which is allowed to run past real code, is fixed.
+			pos += inst.Len // step over the RET itself first -- otherwise the very
+			// first iteration would test the RET opcode 0xc3 against padByte and
+			// wrongly report "function is too short to patch", and would re-decode
+			// the same RET forever.
+			for pos < required {
+				if !(code[pos] == padByte || !checkLen) {
+					return 0, errors.New(errFunctionTooShort)
+				}
+				inst, err = x86asm.Decode(code[pos:], 64)
+				if err != nil {
+					return 0, err
+				}
+				pos += inst.Len
+			}
+			// Bound check for the caller: pos < required <= len(hookCode) == 12 on
+			// entry to the last iteration, and an x86 instruction is at most 15 bytes,
+			// so pos <= 26 here -- well inside the 64-byte targetCodeBuf and nowhere
+			// near the page the trampoline is written into.
+			return pos, nil
+		}
 		pos += inst.Len
 	}
-	return pos
+	return pos, nil
 }
 
 func GetGenericJumpAddr(addr uintptr, maxScan uint64) uintptr {

--- a/internal/monkey/inst/disasm_amd64_test.go
+++ b/internal/monkey/inst/disasm_amd64_test.go
@@ -1,0 +1,208 @@
+/*
+ * Copyright 2022 ByteDance Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package inst
+
+import (
+	"testing"
+
+	"golang.org/x/arch/x86/x86asm"
+)
+
+// branchLen is the width of the branch sequence Disassemble is asked to make
+// room for on amd64: MOV RDX, imm64 (10 bytes) + JMP RDX (2 bytes).
+// It matches len(BranchInto(...)), which is what patch.go passes as `required`.
+const branchLen = 12
+
+// ret is a single-byte RET (0xc3), i.e. the shortest possible function body.
+const ret = 0xc3
+
+// TestDisassembleShortFunction covers the case where the target function ends
+// before `required` bytes. Overwriting past its RET is safe only when the
+// remaining bytes are linker padding rather than a neighbouring function.
+func TestDisassembleShortFunction(t *testing.T) {
+	// A real function prologue, used as the "neighbour" that must not be clobbered:
+	// MOV RBP, RSP; SUB RSP, 0x10; TEST RAX, RAX; JNE ...
+	neighbour := []byte{0x48, 0x89, 0xe5, 0x48, 0x83, 0xec, 0x10, 0x48, 0x85, 0xc0, 0x75, 0xcc}
+
+	padded := func(prefix []byte) []byte {
+		out := append([]byte{}, prefix...)
+		for len(out) < 32 {
+			out = append(out, padByte)
+		}
+		return out
+	}
+
+	tests := []struct {
+		name    string
+		code    []byte
+		wantErr bool
+	}{
+		{
+			name: "one byte function followed by padding",
+			code: padded([]byte{ret}),
+		},
+		{
+			// LEA RCX, [RAX+RAX*2]; LEA RCX, [RCX+7]; ADD RBX, RAX; RET at offset 10.
+			name: "function ending just before the branch width",
+			code: padded([]byte{0x48, 0x8d, 0x0c, 0x40, 0x48, 0x8d, 0x49, 0x07, 0x48, 0x01, 0xc3}),
+		},
+		{
+			name:    "one byte function followed by a neighbour",
+			code:    append([]byte{ret}, neighbour...),
+			wantErr: true,
+		},
+		{
+			// MOV RAX, RCX; RET; two bytes of padding; then a neighbour that
+			// still starts inside the window we would overwrite.
+			name:    "padding that ends before the branch width",
+			code:    append([]byte{0x48, 0x89, 0xc8, ret, padByte, padByte}, neighbour...),
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := recoverOf(func() { Disassemble(tt.code, branchLen, true) })
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected Disassemble to refuse, but it returned")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("expected Disassemble to accept, got %v", err)
+			}
+			// The cutting index must span the whole branch sequence, otherwise
+			// Unpatch would restore fewer bytes than Patch overwrote.
+			if got := Disassemble(tt.code, branchLen, true); got != branchLen {
+				t.Fatalf("cutting index = %d, want %d", got, branchLen)
+			}
+		})
+	}
+}
+
+// TestDisassembleShortFunctionUnsafe pins the OptUnsafe path: when the caller
+// opts out of the length check, Disassemble must not refuse for any reason.
+func TestDisassembleShortFunctionUnsafe(t *testing.T) {
+	code := []byte{ret, 0x48, 0x89, 0xe5, 0x48, 0x83, 0xec, 0x10, 0x48, 0x85, 0xc0, 0x75, 0xcc}
+	if err := recoverOf(func() { Disassemble(code, branchLen, false) }); err != nil {
+		t.Fatalf("unchecked path must not refuse, got %v", err)
+	}
+}
+
+// TestDisassembleReturnsInstructionBoundary is the regression test for the
+// cutting index landing in the middle of an instruction.
+//
+// patch.go uses the return value both as the length of the prefix copied into
+// the trampoline and as the address it branches back to (targetAddr+cuttingIdx),
+// so a value that is not an instruction boundary produces a trampoline whose
+// last instruction is truncated and whose jump lands mid-instruction. Returning
+// the raw `required` from the RET branch did exactly that whenever the bytes
+// after the RET were real code rather than 0xCC padding, which is reachable via
+// MockUnsafe (checkLen=false).
+func TestDisassembleReturnsInstructionBoundary(t *testing.T) {
+	tests := []struct {
+		name string
+		code []byte
+		want int
+	}{
+		{
+			// The shape seen in a real service: a frameless function with an early
+			// return, whose continuation is a 4-byte IMUL straddling `required`.
+			//   @0 TEST RAX,RAX (3) | @3 JLE +6 (2) | @5 MOV EAX,7 (5)
+			//   @10 RET (1)         | @11 IMUL RAX,RAX (4) -> covers [11,15)
+			// The old code returned 12, i.e. two bytes into that IMUL.
+			name: "early ret followed by a wide instruction",
+			code: []byte{
+				0x48, 0x85, 0xc0, // TEST RAX, RAX
+				0x7e, 0x06, // JLE +6
+				0xb8, 0x07, 0x00, 0x00, 0x00, // MOV EAX, 7
+				ret,                    // RET   @10
+				0x48, 0x0f, 0xaf, 0xc0, // IMUL RAX, RAX  @11..14
+				0x48, 0x83, 0xc0, 0x03, // ADD RAX, 3
+				ret,
+			},
+			want: 15,
+		},
+		{
+			// Padding is INT3, one byte wide, so rounding up cannot overshoot:
+			// the boundary is exactly `required`, same value the old code returned.
+			name: "early ret followed by padding",
+			code: []byte{0x48, 0x89, 0xc8, ret, padByte, padByte, padByte, padByte,
+				padByte, padByte, padByte, padByte, padByte, padByte, padByte, padByte},
+			want: branchLen,
+		},
+		{
+			// A single 2-byte instruction straddling the branch width, so the
+			// boundary sits one byte past `required` rather than on it.
+			name: "early ret followed by a two byte instruction",
+			code: []byte{
+				0x48, 0x85, 0xc0, // TEST RAX, RAX
+				0x7e, 0x06, // JLE +6
+				0xb8, 0x07, 0x00, 0x00, 0x00, // MOV EAX, 7
+				ret,        // RET  @10
+				0x31, 0xc0, // XOR EAX, EAX  @11..12
+				ret,
+			},
+			want: 13,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// checkLen=false is the MockUnsafe path, the only one that is allowed
+			// to walk past real (non-padding) code.
+			got := Disassemble(tt.code, branchLen, false)
+			if got != tt.want {
+				t.Fatalf("cutting index = %d, want %d", got, tt.want)
+			}
+			if got < branchLen {
+				t.Fatalf("cutting index %d is shorter than the branch sequence %d; "+
+					"Unpatch would restore fewer bytes than Patch overwrote", got, branchLen)
+			}
+			if !onInstructionBoundary(t, tt.code, got) {
+				t.Fatalf("cutting index %d is not an instruction boundary", got)
+			}
+		})
+	}
+}
+
+// onInstructionBoundary decodes the byte stream from the top and reports whether
+// idx is reachable by whole instructions, which is the property patch.go needs.
+func onInstructionBoundary(t *testing.T, code []byte, idx int) bool {
+	t.Helper()
+	for pos := 0; pos < len(code); {
+		if pos == idx {
+			return true
+		}
+		if pos > idx {
+			return false
+		}
+		in, err := x86asm.Decode(code[pos:], 64)
+		if err != nil {
+			t.Fatalf("decode at %d: %v", pos, err)
+		}
+		pos += in.Len
+	}
+	return false
+}
+
+func recoverOf(f func()) (err interface{}) {
+	defer func() { err = recover() }()
+	f()
+	return nil
+}

--- a/internal/monkey/inst/disasm_arm64.go
+++ b/internal/monkey/inst/disasm_arm64.go
@@ -17,6 +17,7 @@
 package inst
 
 import (
+	"errors"
 	"reflect"
 	"unsafe"
 
@@ -52,9 +53,22 @@ func calcFnAddrRange(name string, fn func()) (uintptr, uintptr) {
 	return 0, 0
 }
 
+// Disassemble finds the cutting point, panicking when it cannot. Behaviour is
+// unchanged; it delegates to disassemble so that the panicking and probing
+// entry points share one implementation, as on amd64.
 func Disassemble(code []byte, required int, checkLen bool) int {
-	tool.Assert(len(code) > required, "function is too short to patch")
-	return required
+	pos, err := disassemble(code, required, checkLen)
+	tool.Assert(err == nil, err)
+	return pos
+}
+
+// disassemble reports a refusal as an error instead of panicking. See the amd64
+// version for why probing returns an error rather than recovering a panic.
+func disassemble(code []byte, required int, checkLen bool) (int, error) {
+	if len(code) <= required {
+		return 0, errors.New(errFunctionTooShort)
+	}
+	return required, nil
 }
 
 func GetGenericJumpAddr(addr uintptr, maxScan uint64) uintptr {

--- a/internal/monkey/inst/disasm_error_amd64_test.go
+++ b/internal/monkey/inst/disasm_error_amd64_test.go
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2022 ByteDance Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package inst
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestDisassembleReturnsErrorNotPanic pins the one capability the split adds:
+// every refusal reaches the caller as an error, with nothing panicking. This is
+// what lets TryDisassemble avoid recover(), so if it regresses the probing path
+// silently goes back to catching panics -- or to crashing on the ones it forgot.
+func TestDisassembleReturnsErrorNotPanic(t *testing.T) {
+	tests := []struct {
+		name     string
+		code     []byte
+		required int
+		checkLen bool
+		wantErr  string
+	}{
+		{
+			// Ends at a RET after one byte, and the tail is real code rather than
+			// 0xCC padding, so the branch sequence would overwrite the next function.
+			name:     "too short and tail is not padding",
+			code:     []byte{ret, 0x48, 0x89, 0xc8, 0x48, 0x89, 0xc8, 0x48, 0x89, 0xc8, 0x48, 0x89, 0xc8},
+			required: branchLen,
+			checkLen: true,
+			wantErr:  errFunctionTooShort,
+		},
+		{
+			// 0xff repeated is not a decodable instruction; this is the reason that
+			// used to escape TryDisassemble and crash real repositories.
+			name:     "undecodable instruction",
+			code:     []byte{0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff},
+			required: branchLen,
+			checkLen: true,
+			wantErr:  "unrecognized instruction",
+		},
+		{
+			// The unchecked (MockUnsafe) path skips the length check but still has
+			// to decode, so an undecodable window is refused there too.
+			name:     "undecodable instruction, unchecked path",
+			code:     []byte{0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff},
+			required: branchLen,
+			checkLen: false,
+			wantErr:  "unrecognized instruction",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var (
+				err       error
+				panicked  interface{}
+				completed bool
+			)
+			func() {
+				defer func() { panicked = recover() }()
+				_, err = disassemble(tt.code, tt.required, tt.checkLen)
+				completed = true
+			}()
+
+			if !completed {
+				t.Fatalf("disassemble panicked with %v; refusals must be returned", panicked)
+			}
+			if err == nil {
+				t.Fatal("expected a refusal error, got nil")
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("error = %q, want it to contain %q", err.Error(), tt.wantErr)
+			}
+
+			// The same input must still make the panicking facade panic, with the
+			// same text: Disassemble's contract is unchanged.
+			got := recoverOf(func() { Disassemble(tt.code, tt.required, tt.checkLen) })
+			if got == nil {
+				t.Fatal("Disassemble must still panic on a refusal")
+			}
+			if msg, ok := got.(string); !ok || !strings.Contains(msg, tt.wantErr) {
+				t.Fatalf("Disassemble panicked with %#v, want a string containing %q", got, tt.wantErr)
+			}
+
+			// And the probing entry point must report it as a plain false.
+			if _, ok := TryDisassemble(tt.code, tt.required, tt.checkLen); ok {
+				t.Fatal("TryDisassemble must report ok=false for a refusal")
+			}
+		})
+	}
+}
+
+// TestDisassembleSuccessAgreesAcrossEntryPoints checks the happy path stays
+// consistent: all three entry points must return the same cutting index.
+func TestDisassembleSuccessAgreesAcrossEntryPoints(t *testing.T) {
+	code := []byte{0x48, 0x89, 0xc8, 0x48, 0x89, 0xc8, 0x48, 0x89, 0xc8, 0x48, 0x89, 0xc8, 0x48, 0x89, 0xc8}
+
+	pos, err := disassemble(code, branchLen, true)
+	if err != nil {
+		t.Fatalf("disassemble returned %v, want success", err)
+	}
+	if got := Disassemble(code, branchLen, true); got != pos {
+		t.Fatalf("Disassemble = %d, disassemble = %d", got, pos)
+	}
+	got, ok := TryDisassemble(code, branchLen, true)
+	if !ok {
+		t.Fatal("TryDisassemble reported failure on a patchable function")
+	}
+	if got != pos {
+		t.Fatalf("TryDisassemble = %d, disassemble = %d", got, pos)
+	}
+}

--- a/internal/monkey/inst/inst_amd64.go
+++ b/internal/monkey/inst/inst_amd64.go
@@ -16,7 +16,12 @@
 
 package inst
 
-import "unsafe"
+import (
+	"encoding/binary"
+	"unsafe"
+)
+
+const shortBranchSize = 5
 
 func BranchTo(to uintptr) (res []byte) {
 	res = append(res, rdxMOV(to)...)         // MOVABS RDX, to
@@ -28,6 +33,57 @@ func BranchInto(to uintptr) (res []byte) {
 	res = append(res, rdxMOV(to)...)         // MOVABS RDX, to
 	res = append(res, []byte{0xff, 0x22}...) // JMP [RDX]
 	return
+}
+
+func ShortBranchSize() int {
+	return shortBranchSize
+}
+
+func BranchIntoShort(from, to uintptr) ([]byte, bool) {
+	delta, ok := subtractAddress(to, from+shortBranchSize)
+	if !ok || delta < -1<<31 || delta > 1<<31-1 {
+		return nil, false
+	}
+	result := make([]byte, shortBranchSize)
+	result[0] = 0xe9
+	binary.LittleEndian.PutUint32(result[1:], uint32(int32(delta)))
+	return result, true
+}
+
+// nopByte is a one-byte NOP (XCHG EAX, EAX in 64-bit mode). One byte is all we
+// need: PadEntry only ever fills a gap it never intends to execute, so the
+// shortest encoding is the simplest correct one.
+const nopByte = 0x90
+
+// PadEntry extends an entry sequence to exactly width bytes with NOPs.
+//
+// Why this is necessary, rather than cosmetic: the cutting point is rounded up
+// to an instruction boundary, so it is frequently WIDER than the branch we
+// write over it (a five-byte E9 over a six-byte CMP/JBE prologue is the common
+// case). Whatever we do not overwrite is the tail of an instruction whose head
+// is gone -- an orphan. The CPU never sees it, because the E9 leaves before
+// reaching it, so the patch works. But mockey itself reads those bytes back:
+// every later Patch of the same function disassembles the live entry, and an
+// orphan tail decodes as garbage or not at all ("unrecognized instruction").
+//
+// Unpatch restores the full cuttingIdx and so was never the problem; the entry
+// only has to stay decodable WHILE patched, which is exactly the state a leaked
+// (never-unpatched) mock leaves behind.
+//
+// The legacy path gets this for free: its twelve-byte MOVABS+JMP is written
+// over a cut that Disassemble already grew to >= 12, and any excess is padded
+// here too, so both paths now maintain the same invariant -- a patched entry is
+// always a valid instruction stream.
+func PadEntry(code []byte, width int) []byte {
+	if len(code) >= width {
+		return code
+	}
+	padded := make([]byte, width)
+	copy(padded, code)
+	for i := len(code); i < width; i++ {
+		padded[i] = nopByte
+	}
+	return padded
 }
 
 // rdxMOV moves the 64bit value to rdx register, using the following instruction:

--- a/internal/monkey/inst/inst_amd64_test.go
+++ b/internal/monkey/inst/inst_amd64_test.go
@@ -17,6 +17,7 @@
 package inst
 
 import (
+	"encoding/binary"
 	"fmt"
 	"testing"
 
@@ -28,4 +29,25 @@ func Test_rdxMOV(t *testing.T) {
 		inst := fmt.Sprintf("%x", rdxMOV(0x123456789abcef01))
 		convey.So(inst, convey.ShouldEqual, "48ba01efbc9a78563412")
 	})
+}
+
+func TestBranchIntoShort(t *testing.T) {
+	from := uintptr(0x100000)
+	to := uintptr(0x200123)
+	code, ok := BranchIntoShort(from, to)
+	if !ok {
+		t.Fatal("expected target to be reachable")
+	}
+	if len(code) != ShortBranchSize() || code[0] != 0xe9 {
+		t.Fatalf("short branch = %x", code)
+	}
+	delta := int64(int32(binary.LittleEndian.Uint32(code[1:])))
+	got, valid := addSigned(from+uintptr(len(code)), delta)
+	if !valid || got != to {
+		t.Fatalf("short branch target = 0x%x, want 0x%x", got, to)
+	}
+
+	if _, ok := BranchIntoShort(from, from+1<<31+uintptr(ShortBranchSize())); ok {
+		t.Fatal("expected out-of-range target to be rejected")
+	}
 }

--- a/internal/monkey/inst/inst_arm64.go
+++ b/internal/monkey/inst/inst_arm64.go
@@ -36,6 +36,44 @@ func BranchInto(to uintptr) (res []byte) {
 	return
 }
 
+func ShortBranchSize() int {
+	return 0
+}
+
+func BranchIntoShort(_, _ uintptr) ([]byte, bool) {
+	return nil, false
+}
+
+// nopBytes is the arm64 NOP encoding (little-endian 0xd503201f). Zero would be
+// UDF #0, so padding with it turns an unreachable tail into a SIGILL the moment
+// it stops being unreachable.
+var nopBytes = [4]byte{0x1f, 0x20, 0x03, 0xd5}
+
+// PadEntry cannot currently pad anything on arm64, but it pads correctly when
+// it does.
+//
+// The reason it is unreachable is not that instructions are four bytes wide --
+// that alone would not stop a cutting point from exceeding the entry sequence.
+// It is that disassemble on this architecture returns `required` verbatim
+// without stepping through instructions, so cuttingIdx is always exactly
+// len(hookCode) and the guard below always takes the early return.
+//
+// That is a property of the current arm64 disassembler, not of the
+// architecture, so it is worth not depending on. Should arm64 ever round its
+// cutting point up to an instruction boundary the way amd64 does, this fills
+// with NOPs like its amd64 counterpart instead of leaving zeroes behind.
+func PadEntry(code []byte, width int) []byte {
+	if len(code) >= width {
+		return code
+	}
+	padded := make([]byte, width)
+	copy(padded, code)
+	for i := len(code); i < width; i++ {
+		padded[i] = nopBytes[i%4]
+	}
+	return padded
+}
+
 const x26 uint32 = 0b11010
 
 // x26MOV moves the 64bit value to x26 register, using the following four instructions:

--- a/internal/monkey/inst/relocate_amd64.go
+++ b/internal/monkey/inst/relocate_amd64.go
@@ -1,0 +1,239 @@
+/*
+ * Copyright 2022 ByteDance Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package inst
+
+import (
+	"encoding/binary"
+	"fmt"
+
+	"golang.org/x/arch/x86/x86asm"
+)
+
+type decodedInst struct {
+	oldOffset int
+	newOffset int
+	newLen    int
+	inst      x86asm.Inst
+}
+
+func HasPCRelative(code []byte) bool {
+	for pos := 0; pos < len(code); {
+		decoded, err := x86asm.Decode(code[pos:], 64)
+		if err != nil || decoded.Len == 0 || pos+decoded.Len > len(code) {
+			return true
+		}
+		if decoded.PCRel != 0 {
+			return true
+		}
+		pos += decoded.Len
+	}
+	return false
+}
+
+func Relocate(code []byte, oldAddr, newAddr uintptr) ([]byte, error) {
+	decoded, newSize, err := decodeForRelocation(code)
+	if err != nil {
+		return nil, err
+	}
+	offsets := make(map[int]int, len(decoded))
+	for _, item := range decoded {
+		offsets[item.oldOffset] = item.newOffset
+	}
+
+	result := make([]byte, newSize)
+	for _, item := range decoded {
+		oldBytes := code[item.oldOffset : item.oldOffset+item.inst.Len]
+		newBytes := result[item.newOffset : item.newOffset+item.newLen]
+		if item.inst.PCRel == 0 {
+			copy(newBytes, oldBytes)
+			continue
+		}
+
+		displacement, err := readSigned(oldBytes[item.inst.PCRelOff:], item.inst.PCRel)
+		if err != nil {
+			return nil, err
+		}
+		oldNext := oldAddr + uintptr(item.oldOffset+item.inst.Len)
+		target, ok := addSigned(oldNext, displacement)
+		if !ok {
+			return nil, fmt.Errorf("pc-relative target overflows address space")
+		}
+
+		isControl := hasRelativeControl(item.inst)
+		if isControl && target >= oldAddr && target < oldAddr+uintptr(len(code)) {
+			mapped, exists := offsets[int(target-oldAddr)]
+			if !exists {
+				return nil, fmt.Errorf("relative branch targets the middle of a copied instruction")
+			}
+			target = newAddr + uintptr(mapped)
+		}
+
+		newNext := newAddr + uintptr(item.newOffset+item.newLen)
+		newDisplacement, ok := subtractAddress(target, newNext)
+		if !ok {
+			return nil, fmt.Errorf("relocated target is outside the supported address range")
+		}
+
+		if item.inst.PCRel == 1 && isControl {
+			opcodeOffset := item.inst.PCRelOff - 1
+			if opcodeOffset < 0 {
+				return nil, fmt.Errorf("unsupported rel8 instruction %s", item.inst.Op)
+			}
+			switch oldBytes[opcodeOffset] {
+			case 0xeb:
+				if opcodeOffset != 0 {
+					return nil, fmt.Errorf("unsupported prefixed short jump %s", item.inst.Op)
+				}
+				newBytes[0] = 0xe9
+				if !writeSigned(newBytes[1:], 4, newDisplacement) {
+					return nil, fmt.Errorf("relocated short jump is outside rel32 range")
+				}
+			default:
+				if oldBytes[opcodeOffset] < 0x70 || oldBytes[opcodeOffset] > 0x7f {
+					return nil, fmt.Errorf("unsupported rel8 instruction %s", item.inst.Op)
+				}
+				copy(newBytes, oldBytes[:opcodeOffset])
+				newBytes[opcodeOffset] = 0x0f
+				newBytes[opcodeOffset+1] = 0x80 | (oldBytes[opcodeOffset] & 0x0f)
+				if !writeSigned(newBytes[opcodeOffset+2:], 4, newDisplacement) {
+					return nil, fmt.Errorf("relocated short conditional jump is outside rel32 range")
+				}
+			}
+			continue
+		}
+
+		copy(newBytes, oldBytes)
+		if !writeSigned(newBytes[item.inst.PCRelOff:], item.inst.PCRel, newDisplacement) {
+			return nil, fmt.Errorf("relocated %s is outside rel%d range", item.inst.Op, item.inst.PCRel*8)
+		}
+	}
+	return result, nil
+}
+
+func decodeForRelocation(code []byte) ([]decodedInst, int, error) {
+	var result []decodedInst
+	oldOffset, newOffset := 0, 0
+	for oldOffset < len(code) {
+		decoded, err := x86asm.Decode(code[oldOffset:], 64)
+		if err != nil || decoded.Len == 0 || oldOffset+decoded.Len > len(code) {
+			return nil, 0, fmt.Errorf("decode instruction at offset %d: %v", oldOffset, err)
+		}
+		newLen := decoded.Len
+		if decoded.PCRel == 1 && hasRelativeControl(decoded) {
+			encoded := code[oldOffset : oldOffset+decoded.Len]
+			opcodeOffset := decoded.PCRelOff - 1
+			if opcodeOffset < 0 {
+				return nil, 0, fmt.Errorf("unsupported rel8 instruction %s", decoded.Op)
+			}
+			switch {
+			case opcodeOffset == 0 && encoded[opcodeOffset] == 0xeb:
+				newLen = 5
+			case encoded[opcodeOffset] >= 0x70 && encoded[opcodeOffset] <= 0x7f:
+				newLen = decoded.Len + 4
+			default:
+				return nil, 0, fmt.Errorf("unsupported rel8 instruction %s", decoded.Op)
+			}
+		}
+		result = append(result, decodedInst{
+			oldOffset: oldOffset,
+			newOffset: newOffset,
+			newLen:    newLen,
+			inst:      decoded,
+		})
+		oldOffset += decoded.Len
+		newOffset += newLen
+	}
+	return result, newOffset, nil
+}
+
+func hasRelativeControl(inst x86asm.Inst) bool {
+	for _, arg := range inst.Args {
+		if _, ok := arg.(x86asm.Rel); ok {
+			return true
+		}
+	}
+	return false
+}
+
+func readSigned(data []byte, size int) (int64, error) {
+	if len(data) < size {
+		return 0, fmt.Errorf("pc-relative displacement is truncated")
+	}
+	switch size {
+	case 1:
+		return int64(int8(data[0])), nil
+	case 2:
+		return int64(int16(binary.LittleEndian.Uint16(data))), nil
+	case 4:
+		return int64(int32(binary.LittleEndian.Uint32(data))), nil
+	default:
+		return 0, fmt.Errorf("unsupported pc-relative displacement width %d", size)
+	}
+}
+
+func writeSigned(data []byte, size int, value int64) bool {
+	if len(data) < size {
+		return false
+	}
+	switch size {
+	case 1:
+		if value < -1<<7 || value > 1<<7-1 {
+			return false
+		}
+		data[0] = byte(int8(value))
+	case 2:
+		if value < -1<<15 || value > 1<<15-1 {
+			return false
+		}
+		binary.LittleEndian.PutUint16(data, uint16(int16(value)))
+	case 4:
+		if value < -1<<31 || value > 1<<31-1 {
+			return false
+		}
+		binary.LittleEndian.PutUint32(data, uint32(int32(value)))
+	default:
+		return false
+	}
+	return true
+}
+
+func addSigned(base uintptr, delta int64) (uintptr, bool) {
+	if delta < 0 {
+		magnitude := uintptr(-delta)
+		if magnitude > base {
+			return 0, false
+		}
+		return base - magnitude, true
+	}
+	result := base + uintptr(delta)
+	return result, result >= base
+}
+
+func subtractAddress(target, base uintptr) (int64, bool) {
+	if target >= base {
+		delta := target - base
+		if delta > uintptr(^uint64(0)>>1) {
+			return 0, false
+		}
+		return int64(delta), true
+	}
+	delta := base - target
+	if delta > uintptr(^uint64(0)>>1) {
+		return 0, false
+	}
+	return -int64(delta), true
+}

--- a/internal/monkey/inst/relocate_amd64_test.go
+++ b/internal/monkey/inst/relocate_amd64_test.go
@@ -1,0 +1,144 @@
+/*
+ * Copyright 2022 ByteDance Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package inst
+
+import (
+	"testing"
+
+	"golang.org/x/arch/x86/x86asm"
+)
+
+func TestRelocate(t *testing.T) {
+	t.Run("short conditional branch", func(t *testing.T) {
+		oldAddr := uintptr(0x100000)
+		newAddr := uintptr(0x200000)
+		code := []byte{
+			0x48, 0x85, 0xc0, // TEST RAX, RAX
+			0x74, 0x04, // JE oldAddr+9
+		}
+		relocated, err := Relocate(code, oldAddr, newAddr)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(relocated) != 9 {
+			t.Fatalf("relocated length = %d, want 9", len(relocated))
+		}
+		jump, err := x86asm.Decode(relocated[3:], 64)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if jump.Op != x86asm.JE || jump.PCRel != 4 {
+			t.Fatalf("relocated jump = %v", jump)
+		}
+		got := branchTarget(t, newAddr+3, jump)
+		if want := oldAddr + 9; got != want {
+			t.Fatalf("relocated jump target = 0x%x, want 0x%x", got, want)
+		}
+	})
+
+	t.Run("prefixed short conditional branch", func(t *testing.T) {
+		oldAddr := uintptr(0x100000)
+		newAddr := uintptr(0x200000)
+		// CS is a branch-prediction prefix in 64-bit mode. It remains part of
+		// the encoding when JE rel8 expands to JE rel32.
+		code := []byte{0x2e, 0x74, 0x00}
+		relocated, err := Relocate(code, oldAddr, newAddr)
+		if err != nil {
+			t.Fatal(err)
+		}
+		want := []byte{0x2e, 0x0f, 0x84, 0xfc, 0xff, 0xef, 0xff}
+		if string(relocated) != string(want) {
+			t.Fatalf("relocated = % x, want % x", relocated, want)
+		}
+		jump, err := x86asm.Decode(relocated, 64)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got := branchTarget(t, newAddr, jump); got != oldAddr+3 {
+			t.Fatalf("relocated jump target = 0x%x, want 0x%x", got, oldAddr+3)
+		}
+	})
+
+	t.Run("RIP relative memory", func(t *testing.T) {
+		oldAddr := uintptr(0x300000)
+		newAddr := uintptr(0x380000)
+		code := []byte{0x48, 0x8b, 0x05, 0x98, 0xff, 0x0b, 0x00}
+		original, err := x86asm.Decode(code, 64)
+		if err != nil {
+			t.Fatal(err)
+		}
+		want := pcRelativeTarget(t, oldAddr, original, code)
+
+		relocated, err := Relocate(code, oldAddr, newAddr)
+		if err != nil {
+			t.Fatal(err)
+		}
+		moved, err := x86asm.Decode(relocated, 64)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got := pcRelativeTarget(t, newAddr, moved, relocated); got != want {
+			t.Fatalf("relocated memory target = 0x%x, want 0x%x", got, want)
+		}
+	})
+
+	t.Run("unsupported short loop", func(t *testing.T) {
+		if _, err := Relocate([]byte{0xe2, 0xfe}, 0x100000, 0x200000); err == nil {
+			t.Fatal("expected LOOP relocation to be rejected")
+		}
+	})
+}
+
+func TestHasPCRelative(t *testing.T) {
+	if HasPCRelative([]byte{0x48, 0x85, 0xc0}) {
+		t.Fatal("TEST must be position independent")
+	}
+	if !HasPCRelative([]byte{0x74, 0x04}) {
+		t.Fatal("short conditional jump must be position relative")
+	}
+	if !HasPCRelative([]byte{0x48, 0x8b, 0x05, 0x98, 0xff, 0x0b, 0x00}) {
+		t.Fatal("RIP-relative MOV must be position relative")
+	}
+}
+
+func branchTarget(t *testing.T, address uintptr, inst x86asm.Inst) uintptr {
+	t.Helper()
+	for _, arg := range inst.Args {
+		if rel, ok := arg.(x86asm.Rel); ok {
+			target, valid := addSigned(address+uintptr(inst.Len), int64(rel))
+			if !valid {
+				t.Fatal("branch target overflow")
+			}
+			return target
+		}
+	}
+	t.Fatal("instruction has no relative target")
+	return 0
+}
+
+func pcRelativeTarget(t *testing.T, address uintptr, inst x86asm.Inst, code []byte) uintptr {
+	t.Helper()
+	displacement, err := readSigned(code[inst.PCRelOff:], inst.PCRel)
+	if err != nil {
+		t.Fatal(err)
+	}
+	target, valid := addSigned(address+uintptr(inst.Len), displacement)
+	if !valid {
+		t.Fatal("pc-relative target overflow")
+	}
+	return target
+}

--- a/internal/monkey/inst/relocate_arm64.go
+++ b/internal/monkey/inst/relocate_arm64.go
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2022 ByteDance Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package inst
+
+func HasPCRelative([]byte) bool {
+	return false
+}
+
+func Relocate(code []byte, _, _ uintptr) ([]byte, error) {
+	return append([]byte(nil), code...), nil
+}

--- a/internal/monkey/patch.go
+++ b/internal/monkey/patch.go
@@ -18,6 +18,8 @@ package monkey
 
 import (
 	"reflect"
+	"runtime"
+	"sync"
 
 	"github.com/bytedance/mockey/internal/monkey/common"
 	"github.com/bytedance/mockey/internal/monkey/fn"
@@ -28,14 +30,55 @@ import (
 
 // Patch is a context that holds the address and original codes of the patched function.
 type Patch struct {
-	size int
+	code     []byte
+	original []byte
+	base     uintptr
+	// hook keeps the function value whose address is embedded in a short relay
+	// reachable after Unpatch. See retiredRelays.
+	hook interface{}
+	// shortBranch records that the target's entry is a five-byte E9 into a relay
+	// inside code, which changes who may free that page. See Unpatch.
+	shortBranch bool
+}
+
+type retiredRelay struct {
 	code []byte
-	base uintptr
+	// hook is deliberately a Go reference, rather than the raw address in code.
+	// The garbage collector does not scan executable bytes for pointers.
+	hook interface{}
+}
+
+// retiredRelays keeps relay pages of short-branch patches mapped for the rest
+// of the process. It also retains each relay's hook function value: a goroutine
+// which already executed E9 before Unpatch can still load that value from the
+// relay after the caller releases its Mocker.
+var retiredRelays struct {
+	sync.Mutex
+	pages []retiredRelay
 }
 
 // Unpatch restores the patched function to the original function.
 func (p *Patch) Unpatch() {
-	mem.WriteWithSTW(p.base, p.code[:p.size])
+	mem.WriteWithSTW(p.base, p.original)
+	if p.shortBranch {
+		// Do not unmap. On the legacy path the entry is MOVABS RDX, hook; JMP [RDX],
+		// which goes straight to the hook, so this page is only ever reached through
+		// the proxy the caller holds. The short branch changes that: the entry is a
+		// five-byte E9 into a relay that lives in this very page, so EVERY call to
+		// the target runs through it. A goroutine that has already executed the E9
+		// when Unpatch runs is left executing an unmapped page, which the runtime
+		// reports as an unrecoverable "unexpected fault address <page>+0x20".
+		//
+		// Restoring the entry bytes above does not close the window: the jump has
+		// already happened. Nothing short of knowing that no thread is inside the
+		// relay would make freeing safe, and there is no cheap way to know that, so
+		// retire the page instead. It stays mapped and is never reused, costing one
+		// 4 KiB page per short-branch patch for the life of the process.
+		retiredRelays.Lock()
+		retiredRelays.pages = append(retiredRelays.pages, retiredRelay{code: p.code, hook: p.hook})
+		retiredRelays.Unlock()
+		return
+	}
 	common.ReleasePage(p.code)
 }
 
@@ -53,26 +96,171 @@ func PatchValue(target, hook, proxy reflect.Value, unsafe, generic bool) *Patch 
 	// The first few bytes of the target function code
 	const bufSize = 64
 	targetCodeBuf := common.BytesOf(targetAddr, bufSize)
-	// construct the branch instruction, i.e. jump to the hook function
-	hookCode := inst.BranchInto(common.PtrAt(hook))
-	// search the cutting point of the target code, i.e. the minimum length of full instructions that is longer than the hookCode
-	cuttingIdx := inst.Disassemble(targetCodeBuf, len(hookCode), !unsafe)
+	hookAddr := common.PtrAt(hook)
+	hookCode := inst.BranchInto(hookAddr)
+	var cuttingIdx int
+	var proxyCode []byte
+	var proxyPrefix []byte
+	var usedShortBranch bool
 
-	// construct the proxy code
-	proxyCode := common.AllocatePage()
+	if unsafe || inst.ShortBranchSize() == 0 {
+		// Keep MockUnsafe and non-amd64 architectures on the legacy path.
+		cuttingIdx = disassembleOrExplain(targetAddr, targetCodeBuf, len(hookCode), !unsafe)
+		proxyCode = common.AllocatePage()
+		proxyPrefix = targetCodeBuf[:cuttingIdx]
+	} else if idx, ok := inst.TryDisassemble(targetCodeBuf, len(hookCode), true); ok && !inst.HasPCRelative(targetCodeBuf[:idx]) {
+		// Preserve the existing 12-byte entry sequence when its trampoline prefix
+		// is position independent.
+		cuttingIdx = idx
+		proxyCode = common.AllocatePage()
+		proxyPrefix = targetCodeBuf[:cuttingIdx]
+	} else if shortCode, shortIdx, shortPrefix, shortPage, ok := tryShortBranch(targetAddr, targetCodeBuf, hookAddr); ok {
+		// A five-byte E9 reaches a nearby relay. The relay restores the function
+		// value pointer in RDX before entering the reflect-generated hook.
+		hookCode, cuttingIdx, proxyPrefix, proxyCode = shortCode, shortIdx, shortPrefix, shortPage
+		usedShortBranch = true
+	} else {
+		// The short path is unavailable (target too short for a five-byte cut, no
+		// page within rel32 range, or a prefix we cannot relocate). Fall back to
+		// the legacy 12-byte path so that anything patchable before this change
+		// stays patchable: this path may only ever add capability, never remove
+		// it. If the legacy path cannot handle it either, Disassemble rejects
+		// loudly exactly as it did on the baseline.
+		cuttingIdx = disassembleOrExplain(targetAddr, targetCodeBuf, len(hookCode), true)
+		proxyCode = common.AllocatePage()
+		proxyPrefix = targetCodeBuf[:cuttingIdx]
+	}
+
+	original := append([]byte(nil), targetCodeBuf[:cuttingIdx]...)
+	// cuttingIdx is no longer guaranteed to equal len(hookCode): when the target
+	// ends in an early RET, Disassemble rounds up to the next instruction boundary
+	// past it, so cuttingIdx may exceed len(hookCode) (bounded by 12+15-1 = 26 on
+	// amd64, one branch width plus at most one maximal x86 instruction). Both the
+	// slice read below and the trampoline write must still fit, so pin the two
+	// invariants rather than assume them: targetCodeBuf is bufSize (64) bytes, and
+	// a page is at least 4096 bytes, so neither can fire today -- this is here to
+	// fail loudly instead of corrupting memory if either bound ever changes.
+	tool.Assert(cuttingIdx <= bufSize, "cutting index %v exceeds the %v bytes read from the target", cuttingIdx, bufSize)
+	tool.Assert(len(proxyPrefix)+len(inst.BranchTo(0)) <= len(proxyCode), "trampoline (%v code bytes + branch) does not fit in a %v byte page", len(proxyPrefix), len(proxyCode))
 	// save the original code before the cutting point
-	copy(proxyCode, targetCodeBuf[:cuttingIdx])
+	copy(proxyCode, proxyPrefix)
 	// construct the branch instruction, i.e. jump to the cutting point
-	copy(proxyCode[cuttingIdx:], inst.BranchTo(targetAddr+uintptr(cuttingIdx)))
+	copy(proxyCode[len(proxyPrefix):], inst.BranchTo(targetAddr+uintptr(cuttingIdx)))
 	// inject the proxy code to the proxy function
 	fn.InjectInto(proxy, proxyCode)
 
 	tool.DebugPrintf("PatchValue: hook code len(%v), cuttingIdx(%v)\n", len(hookCode), cuttingIdx)
 
-	// replace target function codes before the cutting point
+	// Replace target function codes before the cutting point.
+	//
+	// Pad to the full cutting point rather than writing only the branch. The
+	// cutting point is rounded up to an instruction boundary, so it is often
+	// wider than the branch -- most visibly a five-byte E9 over a six-byte
+	// CMP/JBE prologue. Bytes inside the cut that we leave alone are the tail of
+	// an instruction whose head we just overwrote. Execution never reaches them,
+	// because the branch leaves first, so the patch itself works either way.
+	//
+	// The reason this is not cosmetic is that mockey reads its own patched code
+	// back: every subsequent PatchValue on the same function disassembles the
+	// live entry to find its cutting point. An orphan tail makes that entry an
+	// invalid instruction stream, and Disassemble rejects it with
+	// "unrecognized instruction" -- naming neither the address nor the real
+	// cause. That is reached whenever a mock is still live when the next one is
+	// built, i.e. any mock that is never unpatched, which is the normal shape of
+	// a Mock(...) at the top level of a test function.
+	//
+	// Unpatch always restored the whole cutting point, so it never contributed:
+	// the entry has to be decodable *while patched*, not only after.
+	hookCode = inst.PadEntry(hookCode, cuttingIdx)
 	mem.WriteWithSTW(targetAddr, hookCode)
 
-	return &Patch{base: targetAddr, code: proxyCode, size: cuttingIdx}
+	return &Patch{base: targetAddr, code: proxyCode, original: original, hook: hook.Interface(), shortBranch: usedShortBranch}
+}
+
+func align(value, alignment int) int {
+	return (value + alignment - 1) &^ (alignment - 1)
+}
+
+// diagnosticBytes is how much of the entry a refusal quotes. Sixteen covers any
+// single x86 instruction (max 15) plus a byte of context, which is enough to
+// tell a mangled entry from a genuinely unpatchable one at a glance.
+const diagnosticBytes = 16
+
+// disassembleOrExplain is inst.Disassemble with the target named in the failure.
+//
+// The bare refusals ("unrecognized instruction", "function is too short to
+// patch") say nothing about which function was refused or what was actually
+// read. That is a problem specific to this refusal: it is the one failure mode
+// that can be caused by a *previous* mock rather than by the target itself, so
+// the caller in the stack trace is frequently not the culprit. Without the
+// address there is nothing to correlate against, and diagnosing it means
+// bisecting the test order by hand.
+//
+// The address is printed both raw and resolved: raw is what the debug ledger
+// (MOCKEY_DEBUG=true) prints, so the two can be matched up directly, and the
+// symbol is what a reader actually recognises.
+func disassembleOrExplain(targetAddr uintptr, code []byte, required int, checkLen bool) int {
+	pos, err := inst.DisassembleErr(code, required, checkLen)
+	if err == nil {
+		return pos
+	}
+	name := "unknown function"
+	if f := runtime.FuncForPC(targetAddr); f != nil {
+		name = f.Name()
+	}
+	quoted := code
+	if len(quoted) > diagnosticBytes {
+		quoted = quoted[:diagnosticBytes]
+	}
+	tool.Assert(false, "%v: cannot patch %v at 0x%x (%v), entry reads % x. "+
+		"If those bytes begin with a branch (E9 or 48 BA ... FF 22), this function is "+
+		"already patched and was never unpatched: unpatch the earlier mock, or build "+
+		"it inside PatchConvey so it is unpatched for you.",
+		err, name, targetAddr, targetAddr, quoted)
+	return 0 // unreachable: Assert(false) always panics
+}
+
+// tryShortBranch builds the five-byte E9 entry sequence plus its near relay
+// page. It reports ok=false instead of panicking whenever the short path is
+// unavailable, so the caller can fall back to the legacy 12-byte path: this
+// feature may only ever add patchable functions, never take one away. Any page
+// allocated on a failing path is released before returning.
+func tryShortBranch(targetAddr uintptr, targetCodeBuf []byte, hookAddr uintptr) (hookCode []byte, cuttingIdx int, proxyPrefix, proxyCode []byte, ok bool) {
+	cuttingIdx, ok = inst.TryDisassemble(targetCodeBuf, inst.ShortBranchSize(), true)
+	if !ok {
+		return nil, 0, nil, nil, false
+	}
+
+	proxyCode, err := common.AllocatePageNear(targetAddr)
+	if err != nil {
+		tool.DebugPrintf("tryShortBranch: allocate near trampoline failed: %v\n", err)
+		return nil, 0, nil, nil, false
+	}
+	proxyAddr := common.PtrOf(proxyCode)
+	proxyPrefix, err = inst.Relocate(targetCodeBuf[:cuttingIdx], targetAddr, proxyAddr)
+	if err != nil {
+		common.ReleasePage(proxyCode)
+		tool.DebugPrintf("tryShortBranch: relocate trampoline failed: %v\n", err)
+		return nil, 0, nil, nil, false
+	}
+
+	branchBack := inst.BranchTo(targetAddr + uintptr(cuttingIdx))
+	relayOffset := align(len(proxyPrefix)+len(branchBack), 16)
+	relayCode := inst.BranchInto(hookAddr)
+	if relayOffset+len(relayCode) > len(proxyCode) {
+		common.ReleasePage(proxyCode)
+		tool.DebugPrintf("tryShortBranch: relay does not fit in proxy page\n")
+		return nil, 0, nil, nil, false
+	}
+	copy(proxyCode[relayOffset:], relayCode)
+
+	hookCode, ok = inst.BranchIntoShort(targetAddr, proxyAddr+uintptr(relayOffset))
+	if !ok {
+		common.ReleasePage(proxyCode)
+		tool.DebugPrintf("tryShortBranch: near trampoline is outside rel32 range\n")
+		return nil, 0, nil, nil, false
+	}
+	return hookCode, cuttingIdx, proxyPrefix, proxyCode, true
 }
 
 func PatchFunc(fn, hook, proxy interface{}, unsafe bool) *Patch {

--- a/internal/monkey/patch_test.go
+++ b/internal/monkey/patch_test.go
@@ -34,6 +34,16 @@ func Hook() int {
 
 func UnsafeTarget() {}
 
+var optimizedGlobal = 41
+
+//go:noinline
+func OptimizedBranchGlobal(value *int) int {
+	if value == nil {
+		return optimizedGlobal
+	}
+	return *value
+}
+
 func TestPatchFunc(t *testing.T) {
 	convey.Convey("TestPatchFunc", t, func() {
 		convey.Convey("normal", func() {
@@ -81,4 +91,32 @@ func TestPatchFunc(t *testing.T) {
 			convey.So(func() { UnsafeTarget() }, convey.ShouldNotPanic)
 		})
 	})
+}
+
+func TestPatchFuncOptimizedTrampoline(t *testing.T) {
+	var proxy func(*int) int
+	patch := PatchFunc(OptimizedBranchGlobal, func(*int) int { return -1 }, &proxy, false)
+	patched := true
+	defer func() {
+		if patched {
+			patch.Unpatch()
+		}
+	}()
+
+	if got := OptimizedBranchGlobal(nil); got != -1 {
+		t.Fatalf("patched target = %d, want -1", got)
+	}
+	value := 7
+	if got := proxy(&value); got != value {
+		t.Fatalf("origin pointer branch = %d, want %d", got, value)
+	}
+	if got := proxy(nil); got != optimizedGlobal {
+		t.Fatalf("origin global branch = %d, want %d", got, optimizedGlobal)
+	}
+
+	patch.Unpatch()
+	patched = false
+	if got := OptimizedBranchGlobal(nil); got != optimizedGlobal {
+		t.Fatalf("unpatched target = %d, want %d", got, optimizedGlobal)
+	}
 }

--- a/internal/monkey/relay_lifetime_amd64_test.go
+++ b/internal/monkey/relay_lifetime_amd64_test.go
@@ -1,0 +1,113 @@
+//go:build amd64 && !windows
+// +build amd64,!windows
+
+/*
+ * Copyright 2022 ByteDance Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package monkey
+
+import (
+	"reflect"
+	"syscall"
+	"testing"
+
+	"github.com/bytedance/mockey/internal/monkey/common"
+)
+
+var relayLiveGlobal = 41
+
+// Shaped so the short-branch path takes it: an early RET, then a RIP-relative
+// global read, which the legacy 12-byte path refuses to copy.
+//
+//go:noinline
+func relayLiveTarget(p *int) int {
+	if p == nil {
+		return relayLiveGlobal
+	}
+	return *p
+}
+
+//go:noinline
+func relayLiveLongTarget(a, b, c int) int {
+	s := a*3 + b*5 + c*7
+	for i := 0; i < 3; i++ {
+		s += i * a
+	}
+	return s
+}
+
+// pageIsMapped answers without touching the page: msync reports ENOMEM for an
+// address that is not mapped.
+func pageIsMapped(addr uintptr) bool {
+	_, _, errno := syscall.Syscall(syscall.SYS_MSYNC, addr&^0xfff, 0x1000, 4 /*MS_ASYNC*/)
+	return errno != syscall.ENOMEM
+}
+
+// TestShortBranchRelayStaysMappedAfterUnpatch is the regression test for an
+// unrecoverable crash seen on a real repository.
+//
+// With the short branch, the target's entry is a five-byte E9 into a relay that
+// lives inside the trampoline page, so every call to the target passes through
+// that page -- not just calls through origin, as on the legacy path. Unpatch
+// used to unmap it, leaving any goroutine that had already taken the jump
+// executing unmapped memory: "unexpected fault address <page>+0x20", a fatal
+// error that recover cannot catch.
+//
+// Restoring the entry bytes does not close the window, because the jump has
+// already happened, so the page must outlive the patch.
+func TestShortBranchRelayStaysMappedAfterUnpatch(t *testing.T) {
+	var proxy func(*int) int
+	p := PatchFunc(relayLiveTarget, func(*int) int { return -1 }, &proxy, false)
+	if !p.shortBranch {
+		t.Skip("target was not patched via the short branch; nothing to pin here")
+	}
+	hook := p.hook
+	relay := common.PtrOf(p.code) + 0x20
+	if !pageIsMapped(relay) {
+		t.Fatal("relay page is not mapped while patched")
+	}
+
+	p.Unpatch()
+
+	if !pageIsMapped(relay) {
+		t.Fatal("relay page was unmapped by Unpatch; an in-flight caller would " +
+			"fault on it unrecoverably")
+	}
+	retiredRelays.Lock()
+	retired := retiredRelays.pages[len(retiredRelays.pages)-1]
+	retiredRelays.Unlock()
+	if reflect.ValueOf(retired.hook).Pointer() != reflect.ValueOf(hook).Pointer() {
+		t.Fatal("retired relay lost the hook function value embedded as a raw address")
+	}
+	if got := relayLiveTarget(nil); got != relayLiveGlobal {
+		t.Fatalf("target not restored: got %d, want %d", got, relayLiveGlobal)
+	}
+}
+
+// The legacy path keeps releasing its page: nothing but origin ever reaches it,
+// so there is no window to protect and no reason to leak.
+func TestLegacyPatchStillReleasesItsPage(t *testing.T) {
+	var proxy func(int, int, int) int
+	p := PatchFunc(relayLiveLongTarget, func(int, int, int) int { return -1 }, &proxy, false)
+	if p.shortBranch {
+		t.Skip("target took the short branch; this test is about the legacy one")
+	}
+	page := common.PtrOf(p.code)
+	p.Unpatch()
+	if pageIsMapped(page) {
+		t.Fatal("legacy trampoline page should still be released by Unpatch")
+	}
+}

--- a/tests/short_jump_test.go
+++ b/tests/short_jump_test.go
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2022 ByteDance Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package tests
+
+import (
+	"testing"
+
+	. "github.com/bytedance/mockey"
+)
+
+var shortJumpGlobal = 41
+
+// The exact shape the short branch exists for: an early RET at nine bytes, then
+// a RIP-relative load of a global. The legacy twelve-byte path refuses this
+// ("function is too short to patch") because the tail is real code rather than
+// 0xCC padding; the short branch copies five bytes instead and relocates them.
+//
+//go:noinline
+func shortJumpTarget(p *int) int {
+	if p == nil {
+		return shortJumpGlobal
+	}
+	return *p
+}
+
+// A function the legacy path has always handled, used as the negative control.
+//
+//go:noinline
+func longEnoughTarget(a int) int { return a*3 + 1 }
+
+// TestShortBranchRescuesShortFunction is the end-to-end test for the feature:
+// mock a function the baseline could not mock, call it, and call origin.
+//
+// It covers the whole chain at once -- five-byte E9, near-page relay,
+// relocation of the copied prefix -- and it is the only test here that would
+// notice the relocation being silently wrong: origin returns the global (41)
+// only if the RIP-relative load was fixed up for its new address, and returns
+// the argument only if the conditional branch was too.
+func TestShortBranchRescuesShortFunction(t *testing.T) {
+	var origin func(*int) int
+	mk := Mock(shortJumpTarget).To(func(p *int) int { return origin(p) + 1000 }).Origin(&origin).Build()
+	defer mk.UnPatch()
+
+	if got := shortJumpTarget(nil); got != 1000+shortJumpGlobal {
+		t.Fatalf("nil branch = %d, want %d", got, 1000+shortJumpGlobal)
+	}
+	v := 7
+	if got := shortJumpTarget(&v); got != 1000+v {
+		t.Fatalf("pointer branch = %d, want %d", got, 1000+v)
+	}
+}
+
+// TestLegacyPathUnchanged is the negative control: a function the legacy path
+// already handled must behave exactly as before, so a green run of the test
+// above cannot be explained by the checks simply being loosened.
+func TestLegacyPathUnchanged(t *testing.T) {
+	var origin func(int) int
+	mk := Mock(longEnoughTarget).To(func(a int) int { return origin(a) + 1000 }).Origin(&origin).Build()
+	if got := longEnoughTarget(5); got != 1016 {
+		t.Fatalf("hook+origin = %d, want 1016", got)
+	}
+	mk.UnPatch()
+	if got := longEnoughTarget(5); got != 16 {
+		t.Fatalf("after unpatch = %d, want 16", got)
+	}
+}


### PR DESCRIPTION
> **Note on the base branch / the conflict marker.** This branch is cut from **`v1.2.15`**, but GitHub only allows a **branch** as a PR base and this repo has no 1.2.x maintenance branch (1.2.x exists only as tags), so the PR is filed against `main`. GitHub therefore shows it as conflicting — that is expected and does not mean the diff is wrong: the merge base of this branch and `main` is exactly `v1.2.15`, so the **21 files / +2058 / −21 shown in "Files changed" are precisely the intended backport**, with no revert of anything on `main`.
>
> **This is not meant to be merged into `main` as-is** — #126 is the change for `main`. If you would like this on the 1.2 line, the natural home is a `release/1.2` branch cut from `v1.2.17`; I am happy to rebase onto whatever you create, or to close this if the 1.2 line is no longer maintained.

## What this PR does

Makes short functions patchable **without `-gcflags=all=-N`** — the **v1.2.x** line.

This is the v1.2.x counterpart of #126. **#126 targets `main` (1.4.x) and is the primary proposal**; this one applies the same change set on top of **v1.2.15**, for users who are still on the 1.2 line.

## Why a separate PR for 1.2.x

1.2.x is still where the large majority of real usage sits, and moving from 1.2.x to 1.4.x is **not a drop-in upgrade**. Comparing the exported API of `v1.2.17` against `main`:

- `MockeyPrivate` is gone
- `Private` changed from an `interface` to a `struct`
- `GenericInfo` became an alias of `fn.GenericInfo`, losing its `Equal` and `UsedParamType` methods
- `Mock` / `MockGeneric` / `MockUnsafe` changed option type (`optionFn` → `mockOptionFn`), so any call site passing an option explicitly breaks
- `GetMethod` gained a variadic parameter and a return value

The module path and the `go` directive are unchanged, so this is not a `/v2` boundary — but it is a source-incompatible step. Asking 1.2.x users to take that step in order to drop `-N` couples an unrelated migration to a build-time fix.

**I recognise 1.2.x may simply not be maintained anymore** — `v1.2.17` was the last tag on that line and `v1.3.0` followed two weeks later. If that is the case, please just close this and I will carry it downstream; no objection. The branch is offered because the change is already written, tested, and running.

## Relationship to #126

Same idea, same approach, **narrower scope**: this branch is **linux/amd64 only**.

The arm64 near-trampoline half of #126 is deliberately **not** backported. v1.2.15's arm64 write path has no instruction-cache maintenance (no `DSB` / `IC IVAU` / `ISB`), and `WriteWithSTW` does not suspend sysmon (the fix for #68); both landed after v1.2.15. The arm64 port itself was written and does pass its tests on this base, but shipping it here would trade a loud, correct refusal ("function is too short to patch") for a **quiet miscompile** on a write path that does not reliably publish bytes. `darwin/arm64` therefore keeps v1.2.15's behaviour exactly — that is the status quo, not a regression introduced here.

For the same reason, **please review #126 first**. If the approach is not wanted there, it should not land here either.

## The change set

**1. Relax the "too short" check.** After a `RET`, refuse only if the remaining bytes are **not** padding. The linker aligns every function entry to 32 bytes and fills the gap with `0xCC`, and independently keeps functions at least `MINFUNC = 16` bytes apart. Measured across six real linux/amd64 builds (`-l`, `-N -l`, default, PIE, race, large stdlib), ~34000 function symbols: zero functions closer together than the branch sequence, every entry 32-byte aligned, all 88326 padding bytes `0xCC`, and no direct branch target in `.text` lands inside padding.

**2. A 5-byte `E9` short jump with a relocated trampoline prefix.** The 12-byte sequence stays the default. When the target is too short for it, mockey writes a 5-byte `E9 rel32` into a relay page allocated within `rel32` range, lowering the entry requirement from 12 bytes to 5. Relative branches in the copied prefix are explicitly relocated (`rel8` widened to `rel32`, prefixes preserved); anything that cannot be relocated is refused rather than silently miscomputed. If the near page cannot be allocated, the patch **falls back to the legacy 12-byte path** rather than failing.

**3. A latent memory-safety bug: pad the entry to the cutting point.**

This one is worth reading even if you take nothing else from this PR, because **it also affects `main`** (it is item 4 of #126).

The cutting point is rounded up to an instruction boundary, so it is routinely **wider than the branch written over it** — a 5-byte `E9` over a 6-byte `CMP`/`JBE` prologue is the common case. Whatever part of the cut was not written kept the **tail of an instruction whose head was gone**.

Execution never reaches those bytes (the branch leaves first), so the patch works and end-to-end tests pass. But **mockey reads its own patched code back**: every subsequent `PatchValue` on the same function disassembles the live entry to find a cutting point. An orphan tail makes that entry an invalid instruction stream, rejected with a bare `unrecognized instruction`. Reaching it needs only one mock still live when the next is built — exactly what a `Mock(...)` at the top level of a test function always leaves behind. In the observed case the orphan byte was the `JBE`'s displacement `0x37`, which decodes as `AAA`, an instruction that does not exist in 64-bit mode.

The legacy 12-byte path rounds up the same way and could strand a tail too; it is simply harder to hit because its cut starts wider. **Both paths now pad.**

**4. Supporting fixes**

- `Disassemble` returns an instruction boundary from the `RET` branch, instead of a byte count that can fall mid-instruction.
- `TryDisassemble` swallows *every* `Disassemble` panic, not only "too short". Probing with a 5-byte window lands mid-instruction far more often than a 12-byte one; without this, one CI run produced **60 `unrecognized instruction` lines across 8 targets** that the legacy path had rejected cleanly — turning a clean rejection into a crash, exactly the regression the fallback was meant to prevent.
- The short-branch relay page stays mapped after `Unpatch`, and retired relay hook values stay reachable — otherwise a thread still executing an old trampoline runs off unmapped memory. The observed fault addresses `0x3fa020` and `0x3f2020` are both `page+0x20`, the `relayOffset` that `align()` produces for every prefix length the short path accepts.
- Prefixes are preserved when widening short conditional branches.
- Refusals now name the target and quote its bytes, instead of failing anonymously.
- Entry padding on arm64 is `NOP`, not zero (zero is `UDF #0`).

## Why it matters: measured impact

Applied to **three large internal Go services** (200 / 207 / 794 Bazel test targets), replacing `-gcflags=all=-N -l` with `-gcflags=all=-l`:

| | test-artifact size | wall-clock build time |
|---|---|---|
| service A (200 targets) | **×0.71** | ×0.59 |
| service B (207 targets) | **×0.74** | ×0.81 |
| service C (794 targets) | **×0.80** | ×0.83 |

**How to read these numbers, precisely:**

- **Size is the strong result.** Build artifacts are deterministic: repeated runs produced identical byte counts, zero variance. A 20–29% reduction in test-binary bytes is a direct consequence of dropping `-N`.
- **Time was measured with remote caching disabled**, on cold builds, so cache hits could not drown out the signal. The absolute durations therefore do not represent a warm CI; the A/B ratios do. Time ratios are quoted at the **most conservative** pairing (slowest B run vs fastest A run). The A and B ranges do not overlap in any of the three services.
- **Only two end-to-end metrics were measured: total wall-clock time and artifact size.** There is no per-phase data. Attributing the speedup to reduced link-stage contention is a **mechanistic explanation, not a measurement**.
- These numbers were measured on **this** branch's change set — those services build against the 1.2 line, which is what motivated this backport in the first place.

Beyond the numbers, dropping `-N` means the code under test is closer to what ships. One real instance: a hook that saved a map header rather than copying it produced a `SIGSEGV` (and, intermittently, a spurious `concurrent map read and map write` in a single-goroutine test) once optimisation was re-enabled and escape analysis started stack-allocating the caller's map. **That hazard was present under `-N` too** — the header was already being clobbered; the page just happened to stay readable. It was green by luck, not by correctness.

## Testing

`go test -gcflags=all=-l ./...` passes on **all 10 packages** on `linux/amd64` (golang:1.23). `-N -l` is unaffected.

New tests cover both directions rather than only the happy path: padding after `RET` is accepted while a real neighbouring function after `RET` is still rejected; `OptUnsafe` still bypasses the check; a patched entry is asserted to remain a valid instruction stream; re-patching over an entry with an illegal orphan byte is pinned as a regression test; and the relay page's lifetime across `Unpatch` is probed directly.

The orphan-byte regression test is guarded by a second test asserting its fixture is still valid — the orphan byte is chosen by the compiler, so if a future toolchain emits a decodable byte there, the guard fires instead of the regression test silently degrading into a test that can never fail.

**Note on `darwin/arm64` for this base:** v1.2.15 is not fully green there even in its own documented `-N -l` mode, independently of this branch (`TestGenericArg`/`Ret`/`ArgRet` and `TestUnpatchAll_Convey` fail, with intermittent `traceback did not unwind completely`). That is pre-existing and is part of why the arm64 half is excluded here.

## Scope and known limits

- **linux/amd64 only.** Other platforms keep existing behaviour.
- `MockUnsafe` keeps the legacy path.
- Squashed into a single commit deliberately, since it is a backport of an already-reviewable series; happy to split it if that helps review.

---
*Drafted by claude-opus-5.*
