### PR TITLE
feat: support Go 1.27

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -13,10 +13,11 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.26"
+          go-version: "1.27.x"
       - name: Unit Test
         run: go test -gcflags="all=-l -N" -coverprofile=coverage.txt -timeout 30s -count 1 ./...
       - name: Upload results to Codecov
+        if: github.repository == 'bytedance/mockey'
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -15,7 +15,16 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Check Spell
-        uses: crate-ci/typos@master
+        # Use pinned CLI releases because the upstream action policy restricts
+        # third-party action wrappers. Keep the spelling check and config.
+        run: |
+          curl --fail --silent --show-error --location --retry 3 \
+            https://github.com/crate-ci/typos/releases/download/v1.35.7/typos-v1.35.7-x86_64-unknown-linux-musl.tar.gz \
+            --output "$RUNNER_TEMP/typos.tar.gz"
+          echo "e45305520ae975c92d5636b26f26f91f76cc4121f0b7ea3c8897bda807ff8f52  $RUNNER_TEMP/typos.tar.gz" | sha256sum --check --strict
+          mkdir -p "$RUNNER_TEMP/typos-bin"
+          tar -xzf "$RUNNER_TEMP/typos.tar.gz" -C "$RUNNER_TEMP/typos-bin"
+          "$RUNNER_TEMP/typos-bin/typos"
 
   staticcheck:
     runs-on: ubuntu-latest
@@ -40,6 +49,12 @@ jobs:
           go-version: "1.27.x"
       - name: Golangci Lint
         # https://golangci-lint.run/
-        uses: golangci/golangci-lint-action@v8
-        with:
-          version: v2.13.2
+        run: |
+          curl --fail --silent --show-error --location --retry 3 \
+            https://github.com/golangci/golangci-lint/releases/download/v2.13.2/golangci-lint-2.13.2-linux-amd64.tar.gz \
+            --output "$RUNNER_TEMP/golangci-lint.tar.gz"
+          echo "2277d43b98ec0054280f2ac26b53268bae97682444678a59a657dd565da021d6  $RUNNER_TEMP/golangci-lint.tar.gz" | sha256sum --check --strict
+          mkdir -p "$RUNNER_TEMP/golangci-lint-bin"
+          tar -xzf "$RUNNER_TEMP/golangci-lint.tar.gz" -C "$RUNNER_TEMP/golangci-lint-bin" --strip-components=1
+          "$RUNNER_TEMP/golangci-lint-bin/golangci-lint" config verify
+          "$RUNNER_TEMP/golangci-lint-bin/golangci-lint" run --timeout=5m

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -1,14 +1,17 @@
 name: Pull Request Check
 
-on: [ pull_request ]
+on:
+  pull_request:
+  push:
+    branches: [feature/go1.27-runtime]
 
 jobs:
   compliant:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Check License Header
-        uses: apache/skywalking-eyes/header@v0.4.0
+        uses: apache/skywalking-eyes/header@v0.7.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Check Spell
@@ -17,39 +20,26 @@ jobs:
   staticcheck:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5
         with:
-          go-version: 1.19
-      - uses: actions/cache@v3
-        with:
-          path: ~/go/pkg/mod
-          key: reviewdog-${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            reviewdog-${{ runner.os }}-go-
-      - uses: reviewdog/action-staticcheck@v1
-        with:
-          github_token: ${{ secrets.github_token }}
-          # Change reviewdog reporter if you need [github-pr-check,github-check,github-pr-review].
-          reporter: github-pr-review
-          # Report all results.
-          filter_mode: nofilter
-          # Exit with 1 when it find at least one finding.
-          fail_on_error: true
-          # Set staticcheck flags
-          staticcheck_flags: -checks=inherit,-SA1029
+          go-version: "1.27.x"
+      - name: Staticcheck
+        run: |
+          go install honnef.co/go/tools/cmd/staticcheck@v0.8.1
+          staticcheck -checks=inherit,-SA1029 ./...
 
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5
         with:
-          go-version: 1.19
+          go-version: "1.27.x"
       - name: Golangci Lint
         # https://golangci-lint.run/
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@v8
         with:
-          version: latest
+          version: v2.13.2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,9 +1,13 @@
 name: Tests
 
-on: [pull_request]
+on:
+  pull_request:
+  push:
+    branches: [feature/go1.27-runtime]
 
 jobs:
   unit-benchmark-test:
+    if: github.event_name == 'pull_request'
     strategy:
       matrix:
         go: [
@@ -19,24 +23,21 @@ jobs:
           ]
         os: [linux] # should be [ macOS, linux, windows ], but currently we don't have macOS and windows runners
         arch: [X64, ARM64]
-        exclude:
-          - os: Linux
-            arch: ARM64
-          - os: Windows
-            arch: ARM64
     runs-on: ["${{ matrix.os }}", "${{ matrix.arch }}"]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5
         with:
           go-version: ${{ matrix.go }}
+          cache: false
       - name: Unit Test
         run: MOCKEY_DEBUG=true go test -gcflags="all=-l -N" -race -timeout 30s -count 1 ./...
       - name: Benchmark
         run: go test -gcflags="all=-l -N" -bench=. -benchmem -run=none ./...
 
   unit-benchmark-test-no-race: # some go version -race has fatal issues
+    if: github.event_name == 'pull_request'
     strategy:
       matrix:
         go: [
@@ -48,31 +49,60 @@ jobs:
           ]
         os: [linux] # should be [ macOS, linux, windows ], but currently we don't have macOS and windows runners
         arch: [X64, ARM64]
-        exclude:
-          - os: Linux
-            arch: ARM64
-          - os: Windows
-            arch: ARM64
     runs-on: ["${{ matrix.os }}", "${{ matrix.arch }}"]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5
         with:
           go-version: ${{ matrix.go }}
+          cache: false
       - name: Unit Test
         run: MOCKEY_DEBUG=true go test -gcflags="all=-l -N" -timeout 30s -count 1 ./...
       - name: Benchmark
         run: go test -gcflags="all=-l -N" -bench=. -benchmem -run=none ./...
   unit-benchmark-test-no-suspend-runtime:
+    strategy:
+      matrix:
+        go: ["1.26", "1.27.x"]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5
         with:
-          go-version: "1.26"
+          go-version: ${{ matrix.go }}
       - name: Unit Test
         run: MOCKEY_DEBUG=true go test -gcflags="all=-l -N" -timeout 30s -count 1 -tags mockey_disable_ss,mockey_disable_stw ./...
       - name: Benchmark
+        run: go test -gcflags="all=-l -N" -bench=. -benchmem -run=none ./...
+
+  go127:
+    name: Go 1.27 / ${{ matrix.runner }} / race=${{ matrix.race }}
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        runner: [ubuntu-24.04, ubuntu-24.04-arm, macos-15, macos-15-intel, windows-2022]
+        race: [false, true]
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.27.x"
+      - name: Unit Test
+        env:
+          MOCKEY_DEBUG: "true"
+          TEST_RACE: ${{ matrix.race }}
+        run: |
+          race_flag=
+          if [ "$TEST_RACE" = true ]; then race_flag=-race; fi
+          go test -gcflags="all=-l -N" $race_flag -timeout 90s -count 1 ./...
+      - name: Benchmark
+        if: ${{ !matrix.race }}
         run: go test -gcflags="all=-l -N" -bench=. -benchmem -run=none ./...

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,34 +1,38 @@
-# Options for analysis running.
-run:
-  # include `vendor` `third_party` `testdata` `examples` `Godeps` `builtin`
-  skip-dirs-use-default: true
-  skip-files:
-    - ".*\\.mock\\.go$"
-# output configuration options
-output:
-  # Format: colored-line-number|line-number|json|tab|checkstyle|code-climate|junit-xml|github-actions
-  format: colored-line-number
-# All available settings of specific linters.
-# Refer to https://golangci-lint.run/usage/linters
-linters-settings:
-  gofumpt:
-    # Choose whether to use the extra rules.
-    # Default: false
-    extra-rules: true
-  govet:
-    # Disable analyzers by name.
-    # Run `go tool vet help` to see all analyzers.
-    disable:
-      - stdmethods
+version: "2"
 linters:
-  enable:
-    - gofumpt
-    - gofmt
   disable:
     - errcheck
-    - typecheck
-    - deadcode
-    - varcheck
     - staticcheck
-issues:
-  exclude-use-default: true
+  settings:
+    govet:
+      disable:
+        - stdmethods
+        # Inline modernization suggestions can require APIs newer than Go 1.13.
+        - inline
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+      - ".*\\.mock\\.go$"
+formatters:
+  enable:
+    - gofmt
+    - gofumpt
+  settings:
+    gofumpt:
+      extra:
+        group-params: true
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+      - ".*\\.mock\\.go$"

--- a/.licenserc.yaml
+++ b/.licenserc.yaml
@@ -1,7 +1,19 @@
 header:
   license:
     spdx-id: Apache-2.0
-    copyright-owner: 2022 ByteDance Inc.
+    copyright-owner: ByteDance Inc.
+    copyright-year: 2022
+    pattern: |
+      Copyright [0-9]{4}( [0-9]{4})? ByteDance Inc.
+      (Modified in [0-9]{4} .*? )?Licensed under the Apache License, Version 2.0 \(the "License"\);
+      you may not use this file except in compliance with the License.
+      You may obtain a copy of the License at
+      http://www.apache.org/licenses/LICENSE-2.0
+      Unless required by applicable law or agreed to in writing, software
+      distributed under the License is distributed on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+      See the License for the specific language governing permissions and
+      limitations under the License.
   paths:
     - "**/*.go"
     - "**/*.s"

--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ func TestWin(t *testing.T) {
 
 ### Version Support 
 - Go 1.13+
+- Go 1.27 core support includes generic methods and race instrumentation. See the [supported forms and limitations](docs/go1.27-compatibility.md).
 
 ## Basic Features
 ### Simple function/method

--- a/README_cn.md
+++ b/README_cn.md
@@ -100,6 +100,7 @@ func TestWin(t *testing.T) {
 
 ### 版本支持
 - Go 1.13+
+- 核心包支持 Go 1.27，包括泛型方法和 race 检测。支持范围与限制见 [Go 1.27 适配说明](docs/go1.27-compatibility.md)。
 
 ## 基础特性
 ### 简单函数/方法

--- a/_typos.toml
+++ b/_typos.toml
@@ -2,5 +2,9 @@
 [default.extend-identifiers]
 48ba01efbc9a78563412 = "48ba01efbc9a78563412"
 
+[default.extend-words]
+# Conventional abbreviation for reflect.Type; "type" is a Go keyword.
+typ = "typ"
+
 [files]
 extend-exclude = ["go.sum", "check_branch_name.sh"]

--- a/docs/go1.27-compatibility.md
+++ b/docs/go1.27-compatibility.md
@@ -1,0 +1,53 @@
+# Go 1.27 compatibility
+
+Go 1.27 is supported by the core `mockey` package on Linux and macOS AMD64/ARM64, and Windows AMD64. Tests must disable inlining and optimization:
+
+```sh
+go test -gcflags="all=-N -l" ./...
+go test -race -gcflags="all=-N -l" ./...
+```
+
+The experimental `exp/iface` package remains excluded on Go 1.26 and later. Its receiver metadata adaptation is separate from core Go 1.27 support.
+
+## Generic methods
+
+Go 1.27 adds methods with their own type parameters. Applications declaring these methods must enable the Go 1.27 language version in their `go.mod`. Mockey retains its existing module directive and older-toolchain compatibility.
+
+```go
+type Service struct{}
+
+func (s *Service) Echo[T any](value T) T { return value }
+
+func TestEcho(t *testing.T) {
+    service := &Service{}
+    mock := mockey.Mock((*Service).Echo[int]).Return(42).Build()
+    defer mock.UnPatch()
+    if got := service.Echo[int](1); got != 42 {
+        t.Fatalf("got %d, want 42", got)
+    }
+}
+```
+
+Supported forms include declared value/pointer method expressions, generic receiver types, and bound pointer method values such as `service.Echo[int]`. Hooks, variadic parameters, `Origin`, and distinct instantiations sharing a compiler shape are covered by regression tests. A bound pointer-method patch affects the selected instantiation across receivers; its hook uses the receiver-free signature.
+
+Bound value generic method values and promoted generic method expressions fail before patching. Use the declaring receiver's method expression instead, such as `Service.Echo[int]` or `(*Inner).Echo[int]`. Ordinary user closures retain their existing behavior. Generic interface methods are not part of Go 1.27.
+
+## Runtime adaptation
+
+Version-specific runtime layouts and metadata adapters stop at Go 1.28, which requires a new compatibility audit. The implementation follows [runtime layouts](https://github.com/golang/go/blob/go1.27.0/src/runtime/runtime2.go), [function metadata](https://github.com/golang/go/blob/go1.27.0/src/runtime/symtab.go), and [compiler wrapper generation](https://github.com/golang/go/blob/go1.27.0/src/cmd/compile/internal/noder/reader.go).
+
+Race helper lookup handles duplicate ABI entries. Installed patches retain their hook values for garbage collection. Windows runtime sleeps use the Go register calling convention.
+
+Original-function trampolines relocate relative control flow and address generation. A stack-growth retry resumes the active original proxy without repeating conditions, decorators, or counters. Ordinary recursion and calls through older generic patches retain their mocking behavior. This requires tracking active original calls per goroutine; benchmarks cover serial and parallel `Origin` calls.
+
+Distant AMD64 RIP-relative `LEA` instructions use local address literals without changing register width or flags. EIP-relative address generation, distant segment-prefixed `LEA`, and other unsupported distant data references fail explicitly before the target is patched.
+
+## Validation
+
+CI covers Go 1.27 normal/race execution on the five platform combinations above, older Go regression jobs, and runtime-suspension-disabled builds. Additional tests cover generic dictionaries, the standard library `math/rand/v2.Rand.N` method, hook lifetime, forced stack growth, nested patches, and instruction relocation.
+
+Run call-path benchmarks with the same compiler flags:
+
+```sh
+go test -gcflags="all=-N -l" -run='^$' -bench=. -benchmem ./...
+```

--- a/internal/fn/analyzer.go
+++ b/internal/fn/analyzer.go
@@ -1,5 +1,6 @@
 /*
  * Copyright 2022 ByteDance Inc.
+ * Modified in 2026 to support Go 1.27.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -110,12 +111,15 @@ func (a *AnalyzerImpl) runtimeTargetValueAndGenericInfo0() (reflect.Value, Gener
 	if !a.IsGeneric() {
 		return a.TargetValue(), 0
 	}
+	if target, info, ok := a.genericClosureRuntimeTarget(); ok {
+		return target, info
+	}
 	tool.DebugPrintf("[Analyzer.init] try to analyze generic\n")
 	atomic.AddInt64(&genericAnalyzedCount, 1)
 	// Obtain the jump address and generic information address of the generic function through instruction analysis
 	jumpAddr, genericInfoAddr := inst.GetGenericAddr(a.TargetValue().Pointer(), 10000)
 	// Create a function value based on the runtime type and the obtained jump address
-	runtimeTarget, genericInfo := monkeyFn.MakeFunc(a.RuntimeTargetType(), jumpAddr), (GenericInfo)(genericInfoAddr)
+	runtimeTarget, genericInfo := monkeyFn.MakeFunc(a.RuntimeTargetType(), jumpAddr), GenericInfo(genericInfoAddr)
 
 	// Fallback genericInfo: obtains generic information by means of actual execution
 	if genericInfo == 0 {

--- a/internal/fn/analyzer_1_20.go
+++ b/internal/fn/analyzer_1_20.go
@@ -1,8 +1,9 @@
-//go:build go1.20 && !go1.27
-// +build go1.20,!go1.27
+//go:build go1.20 && !go1.28
+// +build go1.20,!go1.28
 
 /*
  * Copyright 2022 ByteDance Inc.
+ * Modified in 2026 to support Go 1.27.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/internal/fn/analyzer_1_20.go
+++ b/internal/fn/analyzer_1_20.go
@@ -26,7 +26,7 @@ import (
 	"github.com/bytedance/mockey/internal/tool"
 )
 
-func NewAnalyzer(target interface{}, generic *bool, method *bool) Analyzer {
+func NewAnalyzer(target interface{}, generic, method *bool) Analyzer {
 	a := &AnalyzerImpl{
 		target:    target,
 		genericIn: generic,
@@ -48,6 +48,7 @@ type AnalyzerImpl struct {
 	runtimeTargetType  reflect.Type
 	runtimeTargetValue reflect.Value
 	runtimeGenericInfo GenericInfo
+	genericClosure     *genericMethodClosure
 }
 
 // init initializes the AnalyzerImpl. If `a.genericIn` or `a.methodIn` is set, it will be used directly, else it will be
@@ -56,6 +57,7 @@ func (a *AnalyzerImpl) init() *AnalyzerImpl {
 	tool.DebugPrintf("[Analyzer.init] start analyze, genericIn: %v, methodIn: %v\n", a.genericIn, a.methodIn)
 	a.targetValue, a.targetType = reflect.ValueOf(a.target), reflect.TypeOf(a.target)
 	tool.DebugPrintf("[Analyzer.init] targetType: %v, targetValue: 0x%x\n", a.targetType, a.targetValue.Pointer())
+	a.initGenericMethodClosure()
 	a.generic, a.method = a.isGeneric0(), a.isMethod0()
 	a.runtimeTargetType = a.runtimeTargetType0()
 	a.runtimeTargetValue, a.runtimeGenericInfo = a.runtimeTargetValueAndGenericInfo0()
@@ -70,7 +72,7 @@ func (a *AnalyzerImpl) isGeneric0() bool {
 	if a.nameAnalyzer == nil {
 		a.nameAnalyzer = NewNameAnalyzerByValue(a.targetValue)
 	}
-	return a.nameAnalyzer.IsGeneric()
+	return a.genericClosure != nil || a.nameAnalyzer.IsGeneric()
 }
 
 func (a *AnalyzerImpl) isMethod0() bool {
@@ -79,6 +81,10 @@ func (a *AnalyzerImpl) isMethod0() bool {
 	}
 	if a.nameAnalyzer == nil {
 		a.nameAnalyzer = NewNameAnalyzerByValue(a.targetValue)
+	}
+
+	if a.genericClosure != nil {
+		return true
 	}
 
 	// Analyze whether the function is a method.
@@ -126,7 +132,9 @@ func (a *AnalyzerImpl) runtimeTargetType0() reflect.Type {
 		targetInShift int
 		targetOut     []reflect.Type
 	)
-	if a.method {
+	if a.genericClosure != nil && a.genericClosure.bound {
+		targetIn = []reflect.Type{a.genericClosure.receiver, genericInfoType}
+	} else if a.method {
 		// for methods, generic information needs to be inserted at position 1 after go1.20
 		targetIn = []reflect.Type{a.targetType.In(0), genericInfoType}
 		targetInShift = 1
@@ -212,6 +220,18 @@ func (a *AnalyzerImpl) nonGenericAnalyzer(inputName string, inputType reflect.Ty
 
 func (a *AnalyzerImpl) genericAnalyzer(inputName string, inputType reflect.Type) (fn, reversedFn) {
 	targetType := a.RuntimeTargetType()
+
+	if a.genericClosure != nil && a.genericClosure.bound {
+		if inputType.NumIn() > 0 && inputType.In(0) == genericInfoType && tool.CheckFuncArgs(targetType, inputType, 2, 1) {
+			return func(args []reflect.Value) []reflect.Value { return args[1:] },
+				func(args, extra []reflect.Value) []reflect.Value { return append([]reflect.Value{extra[0]}, args...) }
+		}
+		tool.Assert(tool.CheckFuncArgs(targetType, inputType, 2, 0), "args not match: target: %v, %s: %v", a.TargetType(), inputName, inputType)
+		return func(args []reflect.Value) []reflect.Value { return args[2:] },
+			func(args, extra []reflect.Value) []reflect.Value {
+				return append([]reflect.Value{extra[0], extra[1]}, args...)
+			}
+	}
 
 	// check function:
 	// 		a. generic function: func(inArgs) outArgs

--- a/internal/fn/analyzer_1_20_test.go
+++ b/internal/fn/analyzer_1_20_test.go
@@ -3,6 +3,7 @@
 
 /*
  * Copyright 2022 ByteDance Inc.
+ * Modified in 2026 to apply the Go 1.27-compatible formatter.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -161,7 +162,6 @@ func newB() b {
 			fmt.Println("hi")
 		},
 		hi: func(int) {
-
 		},
 	}
 }

--- a/internal/fn/analyzer_below_1_20.go
+++ b/internal/fn/analyzer_below_1_20.go
@@ -3,6 +3,7 @@
 
 /*
  * Copyright 2022 ByteDance Inc.
+ * Modified in 2026 to apply the Go 1.27-compatible formatter.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +26,7 @@ import (
 	"github.com/bytedance/mockey/internal/tool"
 )
 
-func NewAnalyzer(target interface{}, generic *bool, method *bool) Analyzer {
+func NewAnalyzer(target interface{}, generic, method *bool) Analyzer {
 	a := &AnalyzerImpl{
 		target:    target,
 		genericIn: generic,
@@ -64,9 +65,7 @@ func (a *AnalyzerImpl) runtimeTargetType0() reflect.Type {
 	if !a.generic {
 		return a.targetType
 	}
-	var (
-		targetIn, targetOut []reflect.Type
-	)
+	var targetIn, targetOut []reflect.Type
 	// generic information needs to be inserted at position 0
 	targetIn = []reflect.Type{genericInfoType}
 	for i := 0; i < a.targetType.NumIn(); i++ {

--- a/internal/fn/generic.go
+++ b/internal/fn/generic.go
@@ -1,5 +1,6 @@
 /*
  * Copyright 2022 ByteDance Inc.
+ * Modified in 2026 to apply the Go 1.27-compatible formatter.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,9 +22,7 @@ import (
 	"unsafe"
 )
 
-var (
-	genericInfoType = reflect.TypeOf(GenericInfo(0))
-)
+var genericInfoType = reflect.TypeOf(GenericInfo(0))
 
 type GenericInfo uintptr
 

--- a/internal/fn/generic_method_closure.go
+++ b/internal/fn/generic_method_closure.go
@@ -1,0 +1,32 @@
+//go:build go1.20 && !go1.28
+// +build go1.20,!go1.28
+
+/*
+ * Copyright 2026 ByteDance Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package fn
+
+import "reflect"
+
+// genericMethodClosure describes Go 1.27's synthetic wrapper for a method
+// with its own type parameters. The receiver and dictionary precede the
+// explicit arguments in the shared implementation's ABI.
+type genericMethodClosure struct {
+	entry      uintptr
+	dictionary GenericInfo
+	receiver   reflect.Type
+	bound      bool
+}

--- a/internal/fn/generic_method_closure_1_27.go
+++ b/internal/fn/generic_method_closure_1_27.go
@@ -1,0 +1,102 @@
+//go:build go1.27 && !go1.28
+// +build go1.27,!go1.28
+
+/*
+ * Copyright 2026 ByteDance Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package fn
+
+import (
+	"reflect"
+	"runtime"
+	"strings"
+	"unsafe"
+
+	monkeyFn "github.com/bytedance/mockey/internal/monkey/fn"
+	"github.com/bytedance/mockey/internal/monkey/inst"
+	"github.com/bytedance/mockey/internal/tool"
+)
+
+func (a *AnalyzerImpl) initGenericMethodClosure() {
+	if a.genericIn != nil && !*a.genericIn {
+		return
+	}
+	a.nameAnalyzer = NewNameAnalyzerByValue(a.targetValue)
+	if !a.nameAnalyzer.IsAnonymousFormat() {
+		return
+	}
+	f := runtime.FuncForPC(a.targetValue.Pointer())
+	// runtime._func.funcID is at byte 40 in Go 1.27. FuncIDWrapper is 23.
+	// Check the compiler's marker as well as the name: a user-written closure
+	// that happens to call a generic method must remain an ordinary function.
+	const funcIDOffset, funcIDWrapper = 40, 23
+	if *(*uint8)(unsafe.Add(unsafe.Pointer(f), funcIDOffset)) != funcIDWrapper {
+		return
+	}
+
+	entry, _ := inst.GetGenericAddr(a.targetValue.Pointer(), 10000)
+	callee := NewNameAnalyzer(runtime.FuncForPC(entry).Name(), false)
+	if !callee.IsGeneric() || !callee.HasMiddleName() || callee.IsAnonymousFormat() {
+		return
+	}
+	captureOffset := inst.GenericClosureCaptureOffset(a.targetValue.Pointer(), 10000)
+	closure := &genericMethodClosure{entry: entry}
+	if captureOffset == 8 && a.targetType.NumIn() > 0 && methodReceiverMatches(a.targetType.In(0), callee) {
+		closure.receiver = a.targetType.In(0)
+	} else {
+		// Pointer method values capture the receiver followed by the dictionary.
+		// unsafe.Pointer has the same ABI and pointer map as every *T and lets
+		// us adapt the bound signature without guessing T from its runtime name.
+		tool.Assert(callee.IsPtrReceiver() && captureOffset == 16,
+			"generic method value or promoted receiver is unsupported; use the declared receiver's method expression")
+		closure.bound = true
+		closure.receiver = reflect.TypeOf(unsafe.Pointer(nil))
+	}
+	// A function value starts with its entry PC. Synthetic method-expression
+	// closures capture just the dictionary; pointer method values capture it
+	// after the receiver. Keep the reflect.Value alive while reading funcval.
+	type functionValue struct {
+		typ  unsafe.Pointer
+		data unsafe.Pointer
+	}
+	value := a.targetValue.Interface()
+	context := (*functionValue)(unsafe.Pointer(&value)).data
+	closure.dictionary = GenericInfo(*(*uintptr)(unsafe.Add(context, captureOffset)))
+	runtime.KeepAlive(value)
+	a.genericClosure = closure
+}
+
+func methodReceiverMatches(receiver reflect.Type, callee *NameAnalyzer) bool {
+	pointer := receiver.Kind() == reflect.Pointer
+	if pointer {
+		receiver = receiver.Elem()
+	}
+	name := receiver.Name()
+	if i := strings.IndexByte(name, '['); i >= 0 {
+		name = name[:i]
+	}
+	if pointer {
+		name = "(*" + name + ")"
+	}
+	return receiver.PkgPath() == callee.PkgName() && name == callee.MiddleName()
+}
+
+func (a *AnalyzerImpl) genericClosureRuntimeTarget() (reflect.Value, GenericInfo, bool) {
+	if a.genericClosure == nil {
+		return reflect.Value{}, 0, false
+	}
+	return monkeyFn.MakeFunc(a.runtimeTargetType, a.genericClosure.entry), a.genericClosure.dictionary, true
+}

--- a/internal/fn/generic_method_closure_below_1_27.go
+++ b/internal/fn/generic_method_closure_below_1_27.go
@@ -1,0 +1,22 @@
+//go:build go1.20 && !go1.27
+// +build go1.20,!go1.27
+
+/*
+ * Copyright 2026 ByteDance Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package fn
+
+func (a *AnalyzerImpl) initGenericMethodClosure() {}

--- a/internal/fn/generic_method_runtime_below_1_27.go
+++ b/internal/fn/generic_method_runtime_below_1_27.go
@@ -1,0 +1,26 @@
+//go:build !go1.27
+// +build !go1.27
+
+/*
+ * Copyright 2026 ByteDance Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package fn
+
+import "reflect"
+
+func (a *AnalyzerImpl) genericClosureRuntimeTarget() (reflect.Value, GenericInfo, bool) {
+	return reflect.Value{}, 0, false
+}

--- a/internal/fn/name_analyzer_1_20.go
+++ b/internal/fn/name_analyzer_1_20.go
@@ -44,9 +44,7 @@ const (
 	ptrReceiverSubstr2 = ")"
 )
 
-var (
-	anonymousNameReg = regexp.MustCompile(`func\d+(\.\d+)*$`)
-)
+var anonymousNameReg = regexp.MustCompile(`func\d+(\.\d+)*$`)
 
 type NameAnalyzer struct {
 	// fullName name from runtime.FuncForPC

--- a/internal/fn/name_analyzer_1_20.go
+++ b/internal/fn/name_analyzer_1_20.go
@@ -1,8 +1,9 @@
-//go:build go1.20 && !go1.27
-// +build go1.20,!go1.27
+//go:build go1.20 && !go1.28
+// +build go1.20,!go1.28
 
 /*
  * Copyright 2022 ByteDance Inc.
+ * Modified in 2026 to support Go 1.27.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/internal/monkey/inst/disasm_amd64.go
+++ b/internal/monkey/inst/disasm_amd64.go
@@ -1,5 +1,6 @@
 /*
  * Copyright 2022 ByteDance Inc.
+ * Modified in 2026 to analyze Go 1.27 generic method closures.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +18,7 @@
 package inst
 
 import (
+	"encoding/binary"
 	"fmt"
 	"reflect"
 
@@ -195,4 +197,73 @@ func (g *genericInfoInst) matchJumpInst(jumpInst *genericJmpInst) bool {
 // LEA RBX, [RIP+0x145d07]
 func (g *genericInfoInst) calcGenericInfoAddr() uintptr {
 	return g.lea.addr + uintptr(g.lea.inst.Len) + uintptr(g.lea.inst.Args[1].(x86asm.Mem).Disp)
+}
+
+// GenericClosureCaptureOffset returns the last captured word loaded by a
+// compiler-generated closure. The closure context register is DX on amd64.
+func GenericClosureCaptureOffset(addr uintptr, maxScan int) uintptr {
+	code := common.BytesOf(addr, maxScan)
+	var offset uintptr
+	for pos := 0; pos < maxScan; {
+		instruction, err := x86asm.Decode(code[pos:], 64)
+		tool.Assert(err == nil, err)
+		if instruction.Op == x86asm.RET {
+			return offset
+		}
+		if instruction.Op == x86asm.CALL {
+			jump := newGenericJmpInst(addr, pos, instruction)
+			if !jump.isExtraCall {
+				return offset
+			}
+		}
+		if instruction.Op == x86asm.MOV {
+			mem, ok := instruction.Args[1].(x86asm.Mem)
+			if ok && mem.Base == x86asm.RDX && mem.Index == 0 && mem.Disp > 0 && uintptr(mem.Disp) > offset {
+				offset = uintptr(mem.Disp)
+			}
+		}
+		pos += instruction.Len
+	}
+	return offset
+}
+
+// RelocateBranches makes relative control flow in the copied prefix target
+// local absolute-jump stubs. In particular, an Origin call can take the stack
+// growth branch even when the original call that reached the hook did not.
+func RelocateBranches(code []byte, original uintptr, prefixEnd, stubOffset int) {
+	for pos := 0; pos < prefixEnd; {
+		instruction, err := x86asm.Decode(code[pos:prefixEnd], 64)
+		tool.Assert(err == nil, err)
+		if instruction.Op == x86asm.RET {
+			return
+		}
+		if relative, ok := instruction.Args[0].(x86asm.Rel); ok {
+			targetOffset := pos + instruction.Len + int(relative)
+			if targetOffset < 0 || targetOffset >= prefixEnd {
+				stub := BranchToOriginal(original + uintptr(targetOffset))
+				tool.Assert(stubOffset+len(stub) <= len(code), "trampoline branch stubs exceed page size")
+				displacement := int64(stubOffset - pos - instruction.Len)
+				switch instruction.PCRel {
+				case 1:
+					tool.Assert(displacement >= -128 && displacement <= 127, "short trampoline branch is out of range")
+					code[pos+instruction.PCRelOff] = byte(int8(displacement))
+				case 4:
+					binary.LittleEndian.PutUint32(code[pos+instruction.PCRelOff:], uint32(int32(displacement)))
+				default:
+					tool.Assert(false, "unsupported relative branch: %v", instruction)
+				}
+				copy(code[stubOffset:], stub)
+				stubOffset += len(stub)
+			}
+		} else if instruction.PCRel != 0 {
+			// RIP-relative data references cannot use a branch island. Keep
+			// them only when their relocated signed displacement still fits.
+			tool.Assert(instruction.PCRel == 4, "unsupported PC-relative instruction: %v", instruction)
+			old := int64(int32(binary.LittleEndian.Uint32(code[pos+instruction.PCRelOff:])))
+			displacement := old + int64(original) - int64(common.PtrOf(code))
+			tool.Assert(displacement == int64(int32(displacement)), "PC-relative data reference is out of trampoline range: %v", instruction)
+			binary.LittleEndian.PutUint32(code[pos+instruction.PCRelOff:], uint32(int32(displacement)))
+		}
+		pos += instruction.Len
+	}
 }

--- a/internal/monkey/inst/disasm_amd64.go
+++ b/internal/monkey/inst/disasm_amd64.go
@@ -237,6 +237,13 @@ func RelocateBranches(code []byte, original uintptr, prefixEnd, stubOffset int) 
 		if instruction.Op == x86asm.RET {
 			return
 		}
+		if instruction.Op == x86asm.LEA {
+			if address, ok := instruction.Args[1].(x86asm.Mem); ok {
+				// x86asm does not mark address-size-prefixed EIP references
+				// as PC-relative. Copying one unchanged would use the proxy PC.
+				tool.Assert(address.Base != x86asm.EIP, "cannot relocate EIP-relative LEA: %v", instruction)
+			}
+		}
 		if relative, ok := instruction.Args[0].(x86asm.Rel); ok {
 			targetOffset := pos + instruction.Len + int(relative)
 			if targetOffset < 0 || targetOffset >= prefixEnd {
@@ -256,11 +263,24 @@ func RelocateBranches(code []byte, original uintptr, prefixEnd, stubOffset int) 
 				stubOffset += len(stub)
 			}
 		} else if instruction.PCRel != 0 {
-			// RIP-relative data references cannot use a branch island. Keep
-			// them only when their relocated signed displacement still fits.
+			// Address generation can load an absolute address from a nearby
+			// literal when the trampoline is outside the original disp32 range.
+			// Other data references must retain their signed displacement.
 			tool.Assert(instruction.PCRel == 4, "unsupported PC-relative instruction: %v", instruction)
 			old := int64(int32(binary.LittleEndian.Uint32(code[pos+instruction.PCRelOff:])))
 			displacement := old + int64(original) - int64(common.PtrOf(code))
+			if displacement != int64(int32(displacement)) && instruction.Op == x86asm.LEA {
+				address, ok := instruction.Args[1].(x86asm.Mem)
+				tool.Assert(ok && instruction.AddrSize == 64 && address.Base == x86asm.RIP && address.Segment == 0,
+					"cannot relocate PC-relative LEA: %v", instruction)
+				tool.Assert(stubOffset >= prefixEnd && stubOffset <= len(code)-8, "trampoline literals exceed page size")
+				// LEA and MOV share ModRM and register/operand-size prefixes.
+				// Replacing the opcode preserves flags and needs no scratch register.
+				code[pos+instruction.PCRelOff-2] = 0x8b
+				binary.LittleEndian.PutUint64(code[stubOffset:], uint64(original+uintptr(pos+instruction.Len)+uintptr(old)))
+				displacement = int64(stubOffset - pos - instruction.Len)
+				stubOffset += 8
+			}
 			tool.Assert(displacement == int64(int32(displacement)), "PC-relative data reference is out of trampoline range: %v", instruction)
 			binary.LittleEndian.PutUint32(code[pos+instruction.PCRelOff:], uint32(int32(displacement)))
 		}

--- a/internal/monkey/inst/disasm_arm64.go
+++ b/internal/monkey/inst/disasm_arm64.go
@@ -1,5 +1,6 @@
 /*
  * Copyright 2022 ByteDance Inc.
+ * Modified in 2026 to analyze Go 1.27 generic method closures.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +18,7 @@
 package inst
 
 import (
+	"encoding/binary"
 	"fmt"
 	"reflect"
 	"unsafe"
@@ -63,11 +65,59 @@ func Disassemble(code []byte, required int, checkLen bool) int {
 	var inst arm64asm.Inst
 
 	for pos < required {
+		if pos+instLen > len(code) {
+			tool.Assert(!checkLen, "function is too short to patch")
+			// MockUnsafe explicitly permits overwriting past a short function.
+			// Its caller will save those overwritten bytes, but instruction
+			// analysis must stay within this function's metadata boundary.
+			return (required + instLen - 1) / instLen * instLen
+		}
 		inst, err = arm64asm.Decode(code[pos:])
 		tool.Assert(err == nil || !checkLen, err)
 		tool.DebugPrintf("Disassemble: %3d\t0x%x\t%v\n", pos, common.PtrOf(code)+uintptr(pos), inst)
 		tool.Assert(inst.Op != arm64asm.RET || !checkLen, "function is too short to patch")
 		pos += instLen
+	}
+	prefixEnd := pos
+	// Go 1.27 may start a stack-only leaf with a zeroing/copy loop rather
+	// than a stack-split prologue. Include any backward branch into the
+	// copied prefix, otherwise Origin jumps back into the patched entry.
+	// The unconditional retry after morestack is not an initialization loop.
+	for scan := pos; scan+instLen <= len(code); scan += instLen {
+		instruction, decodeErr := arm64asm.Decode(code[scan:])
+		if decodeErr != nil || instruction.Op == arm64asm.RET {
+			break
+		}
+		conditional := instruction.Op == arm64asm.CBNZ || instruction.Op == arm64asm.CBZ || instruction.Op == arm64asm.TBNZ || instruction.Op == arm64asm.TBZ
+		if instruction.Op == arm64asm.B {
+			_, conditional = instruction.Args[0].(arm64asm.Cond)
+		}
+		if !conditional {
+			continue
+		}
+		for _, arg := range instruction.Args {
+			if relative, ok := arg.(arm64asm.PCRel); ok {
+				destination := scan + int(relative)
+				if destination >= 0 && destination < pos {
+					pos = scan + instLen
+				}
+			}
+		}
+	}
+	// Relative references in newly copied instructions must stay within the
+	// copied block. Relocating calls and literal/address loads is not supported
+	// by the trampoline; reject them rather than emitting an invalid Origin.
+	for scan := prefixEnd; scan < pos; scan += instLen {
+		instruction, decodeErr := arm64asm.Decode(code[scan:])
+		tool.Assert(decodeErr == nil, decodeErr)
+		for _, arg := range instruction.Args {
+			if relative, ok := arg.(arm64asm.PCRel); ok {
+				destination := scan + int(relative)
+				branch := instruction.Op == arm64asm.B || instruction.Op == arm64asm.CBNZ || instruction.Op == arm64asm.CBZ || instruction.Op == arm64asm.TBNZ || instruction.Op == arm64asm.TBZ
+				tool.Assert(branch && destination >= 0 && destination < pos,
+					"cannot relocate instruction in initialization loop: %v", instruction)
+			}
+		}
 	}
 	return pos
 }
@@ -209,8 +259,8 @@ func (g *genericInfoInst) calcGenericInfoAddr() uintptr {
 	adrpReg := adrpInst.Args[0].(arm64asm.Reg)
 	adrpRes := (g.adrp.addr &^ 0xFFF) + uintptr(adrpInst.Args[1].(arm64asm.PCRel))
 	addInst := g.add.inst
-	tool.Assert(addInst.Args[0].(arm64asm.RegSP) == (arm64asm.RegSP)(adrpReg), "invalid addInst: %v", addInst)
-	tool.Assert(addInst.Args[1].(arm64asm.RegSP) == (arm64asm.RegSP)(adrpReg), "invalid addInst: %v", addInst)
+	tool.Assert(addInst.Args[0].(arm64asm.RegSP) == arm64asm.RegSP(adrpReg), "invalid addInst: %v", addInst)
+	tool.Assert(addInst.Args[1].(arm64asm.RegSP) == arm64asm.RegSP(adrpReg), "invalid addInst: %v", addInst)
 	addImmShift0 := addInst.Args[2].(arm64asm.ImmShift)
 	type immShift struct {
 		imm   uint16
@@ -220,4 +270,107 @@ func (g *genericInfoInst) calcGenericInfoAddr() uintptr {
 	tool.Assert(addImmShift.shift == 0, "invalid addInst: %v", addInst)
 	addRes := adrpRes + uintptr(addImmShift.imm)
 	return addRes
+}
+
+// GenericClosureCaptureOffset returns the last captured word loaded by a
+// compiler-generated closure. Go 1.27 captures a generic method's dictionary
+// after its optional bound receiver. Only inspect the wrapper before RET.
+func GenericClosureCaptureOffset(addr uintptr, maxScan int) uintptr {
+	code := common.BytesOf(addr, maxScan)
+	var offset uintptr
+	for pos := 0; pos < maxScan; pos += instLen {
+		instruction, err := arm64asm.Decode(code[pos:])
+		tool.Assert(err == nil, err)
+		if instruction.Op == arm64asm.RET {
+			return offset
+		}
+		if instruction.Op == arm64asm.BL {
+			jump := newGenericJmpInst(addr, pos, instruction)
+			if !jump.isExtraCall {
+				return offset
+			}
+		}
+		if instruction.Op != arm64asm.LDR && instruction.Op != arm64asm.LDUR {
+			continue
+		}
+		mem, ok := instruction.Args[1].(arm64asm.MemImmediate)
+		if !ok || mem.Base != arm64asm.RegSP(arm64asm.X26) || mem.Mode != arm64asm.AddrOffset {
+			continue
+		}
+		// arm64asm deliberately keeps the displacement private.
+		type memImmediate struct {
+			base arm64asm.RegSP
+			mode arm64asm.AddrMode
+			imm  int32
+		}
+		displacement := (*memImmediate)(unsafe.Pointer(&mem)).imm
+		if displacement > 0 && uintptr(displacement) > offset {
+			offset = uintptr(displacement)
+		}
+	}
+	return offset
+}
+
+// RelocateBranches preserves branch targets when a prologue is copied into
+// the Origin trampoline. External branches use nearby absolute-jump stubs.
+func RelocateBranches(code []byte, original uintptr, prefixEnd, stubOffset int) {
+	for pos := 0; pos < prefixEnd; pos += instLen {
+		instruction, err := arm64asm.Decode(code[pos:prefixEnd])
+		tool.Assert(err == nil, err)
+		if instruction.Op == arm64asm.RET {
+			return
+		}
+		for _, argument := range instruction.Args {
+			relative, ok := argument.(arm64asm.PCRel)
+			if !ok {
+				continue
+			}
+			targetOffset := pos + int(relative)
+			if instruction.Op == arm64asm.ADR || instruction.Op == arm64asm.ADRP {
+				// Replace address generation with a PC-relative load of the
+				// absolute address. The literal stays close to the trampoline
+				// even when mmap is more than 4 GiB from the original text.
+				address := original + uintptr(targetOffset)
+				if instruction.Op == arm64asm.ADRP {
+					address = (original+uintptr(pos))&^0xfff + uintptr(relative)
+				}
+				stubOffset = (stubOffset + 7) &^ 7
+				tool.Assert(stubOffset+8 <= len(code), "trampoline literals exceed page size")
+				register := uint32(instruction.Args[0].(arm64asm.Reg) - arm64asm.X0)
+				encoding := uint32(0x58000000) | uint32((stubOffset-pos)/instLen)<<5 | register
+				binary.LittleEndian.PutUint32(code[pos:], encoding)
+				binary.LittleEndian.PutUint64(code[stubOffset:], uint64(address))
+				stubOffset += 8
+				continue
+			}
+			var shift, width uint
+			switch instruction.Op {
+			case arm64asm.B:
+				shift, width = 0, 26
+				if _, conditional := instruction.Args[0].(arm64asm.Cond); conditional {
+					shift, width = 5, 19
+				}
+			case arm64asm.BL:
+				shift, width = 0, 26
+			case arm64asm.CBZ, arm64asm.CBNZ:
+				shift, width = 5, 19
+			case arm64asm.TBZ, arm64asm.TBNZ:
+				shift, width = 5, 14
+			default:
+				tool.Assert(false, "cannot relocate PC-relative data instruction: %v", instruction)
+			}
+			if targetOffset >= 0 && targetOffset < prefixEnd {
+				continue
+			}
+			stub := BranchToOriginal(original + uintptr(targetOffset))
+			tool.Assert(stubOffset+len(stub) <= len(code), "trampoline branch stubs exceed page size")
+			displacement := int32((stubOffset - pos) / instLen)
+			tool.Assert(displacement >= -(1<<(width-1)) && displacement < 1<<(width-1), "trampoline branch is out of range")
+			mask := uint32((1<<width)-1) << shift
+			encoding := instruction.Enc&^mask | (uint32(displacement) << shift & mask)
+			binary.LittleEndian.PutUint32(code[pos:], encoding)
+			copy(code[stubOffset:], stub)
+			stubOffset += len(stub)
+		}
+	}
 }

--- a/internal/monkey/inst/generic_extra_1_26.go
+++ b/internal/monkey/inst/generic_extra_1_26.go
@@ -1,8 +1,9 @@
-//go:build go1.26 && !go1.27
-// +build go1.26,!go1.27
+//go:build go1.26 && !go1.28
+// +build go1.26,!go1.28
 
 /*
  * Copyright 2022 ByteDance Inc.
+ * Modified in 2026 to support Go 1.27.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/internal/monkey/inst/generic_extra_race.go
+++ b/internal/monkey/inst/generic_extra_race.go
@@ -1,8 +1,9 @@
-//go:build race
-// +build race
+//go:build race && !go1.27
+// +build race,!go1.27
 
 /*
  * Copyright 2022 ByteDance Inc.
+ * Modified in 2026 to support Go 1.27.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/internal/monkey/inst/generic_extra_race_1_27.go
+++ b/internal/monkey/inst/generic_extra_race_1_27.go
@@ -1,0 +1,45 @@
+//go:build race && go1.27 && !go1.28
+// +build race,go1.27,!go1.28
+
+/*
+ * Copyright 2022 ByteDance Inc.
+ * Modified in 2026 to support Go 1.27.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package inst
+
+import (
+	"github.com/bytedance/mockey/internal/monkey/linkname"
+	"github.com/bytedance/mockey/internal/tool"
+)
+
+func init() {
+	// These runtime symbols cannot be referenced with go:linkname in Go 1.27.
+	// Resolve their entry PCs from the function table, which linkname initializes
+	// before this package, to recognize race instrumentation in generic wrappers.
+	// ABIInternal and ABI0 entries can share a name, so register all matching PCs
+	// instead of using FuncPCForName, which keeps only one entry for each name.
+	for _, function := range linkname.FuncList() {
+		switch name := function.Name(); name {
+		case "runtime.racefuncenter", "runtime.racefuncenterfp", "runtime.racefuncexit",
+			"runtime.raceread", "runtime.racewrite", "runtime.racereadrange", "runtime.racewriterange",
+			"runtime.racereadrangepc1", "runtime.racewriterangepc1", "runtime.racecallbackthunk":
+			pc := function.Entry()
+			name = name[len("runtime."):]
+			proxyCallRace[pc] = name
+			tool.DebugPrintf("race func: %x(%v)\n", pc, name)
+		}
+	}
+}

--- a/internal/monkey/inst/generic_extra_race_1_27_test.go
+++ b/internal/monkey/inst/generic_extra_race_1_27_test.go
@@ -1,0 +1,66 @@
+//go:build race && go1.27 && !go1.28
+// +build race,go1.27,!go1.28
+
+/*
+ * Copyright 2026 ByteDance Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package inst
+
+import (
+	"reflect"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func raceGenericIdentity[T any](value T) T {
+	return value
+}
+
+type raceGenericValue[T any] struct {
+	value T
+}
+
+func (value raceGenericValue[T]) Value() T {
+	return value.value
+}
+
+func TestGetGenericAddrRace(t *testing.T) {
+	for _, test := range []struct {
+		name       string
+		target     interface{}
+		calleeName string
+	}{
+		{"scalar", raceGenericIdentity[int], ".raceGenericIdentity["},
+		{"large value", raceGenericIdentity[[32]uint64], ".raceGenericIdentity["},
+		// The pointer wrapper reads the receiver before calling the value method.
+		// Its raceread call uses ABIInternal, even when an ABI0 entry with the
+		// same runtime function name also exists in the executable.
+		{"pointer to value method", (*raceGenericValue[string]).Value, ".raceGenericValue["},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			wrapperPC := reflect.ValueOf(test.target).Pointer()
+			calleePC, _ := GetGenericAddr(wrapperPC, 10000)
+			callee := runtime.FuncForPC(calleePC)
+			if callee == nil {
+				t.Fatalf("generic wrapper resolved to unknown function at %#x", calleePC)
+			}
+			if calleePC == wrapperPC || !strings.Contains(callee.Name(), test.calleeName) {
+				t.Fatalf("generic wrapper resolved to %q, want callee containing %q", callee.Name(), test.calleeName)
+			}
+		})
+	}
+}

--- a/internal/monkey/inst/inst_amd64.go
+++ b/internal/monkey/inst/inst_amd64.go
@@ -1,5 +1,6 @@
 /*
  * Copyright 2022 ByteDance Inc.
+ * Modified in 2026 to preserve closure context in trampoline branches.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,13 +22,13 @@ import "unsafe"
 func BranchTo(to uintptr) (res []byte) {
 	res = append(res, rdxMOV(to)...)         // MOVABS RDX, to
 	res = append(res, []byte{0xff, 0xe2}...) // JMP RDX
-	return
+	return res
 }
 
 func BranchInto(to uintptr) (res []byte) {
 	res = append(res, rdxMOV(to)...)         // MOVABS RDX, to
 	res = append(res, []byte{0xff, 0x22}...) // JMP [RDX]
-	return
+	return res
 }
 
 // rdxMOV moves the 64bit value to rdx register, using the following instruction:
@@ -37,4 +38,14 @@ func rdxMOV(val uintptr) []byte {
 	*(*uintptr)(unsafe.Pointer(&res[0])) = val
 	res = append([]byte{0x48, 0xba}, res...)
 	return res
+}
+
+// BranchToOriginal uses a RIP-relative indirect jump so no live Go register,
+// including the closure context in DX, changes on the way to the original.
+func BranchToOriginal(to uintptr) []byte {
+	code := []byte{0xff, 0x25, 0, 0, 0, 0}
+	for shift := uint(0); shift < 64; shift += 8 {
+		code = append(code, byte(to>>shift))
+	}
+	return code
 }

--- a/internal/monkey/inst/inst_amd64_test.go
+++ b/internal/monkey/inst/inst_amd64_test.go
@@ -1,5 +1,6 @@
 /*
  * Copyright 2022 ByteDance Inc.
+ * Modified in 2026 to verify trampoline branch relocation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,8 +18,11 @@
 package inst
 
 import (
+	"bytes"
 	"fmt"
 	"testing"
+
+	"golang.org/x/arch/x86/x86asm"
 
 	"github.com/smartystreets/goconvey/convey"
 )
@@ -28,4 +32,23 @@ func Test_rdxMOV(t *testing.T) {
 		inst := fmt.Sprintf("%x", rdxMOV(0x123456789abcef01))
 		convey.So(inst, convey.ShouldEqual, "48ba01efbc9a78563412")
 	})
+}
+
+func TestRelocateStackGuardBranch(t *testing.T) {
+	code := make([]byte, 128)
+	for i := 0; i < 16; i++ {
+		code[i] = 0x90
+	}
+	copy(code, []byte{0x0f, 0x86, 0xfa, 0x01, 0, 0}) // JBE original+0x200
+	RelocateBranches(code, 0x1000, 16, 28)
+	instruction, err := x86asm.Decode(code, 64)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := instruction.Len + int(instruction.Args[0].(x86asm.Rel)); got != 28 {
+		t.Fatalf("guard branch goes to %d, want local stub at 28", got)
+	}
+	if want := BranchToOriginal(0x1200); !bytes.Equal(code[28:28+len(want)], want) {
+		t.Fatal("branch stub lost original stack-growth destination")
+	}
 }

--- a/internal/monkey/inst/inst_amd64_test.go
+++ b/internal/monkey/inst/inst_amd64_test.go
@@ -19,9 +19,12 @@ package inst
 
 import (
 	"bytes"
+	"encoding/binary"
 	"fmt"
+	"strings"
 	"testing"
 
+	"github.com/bytedance/mockey/internal/monkey/common"
 	"golang.org/x/arch/x86/x86asm"
 
 	"github.com/smartystreets/goconvey/convey"
@@ -50,5 +53,121 @@ func TestRelocateStackGuardBranch(t *testing.T) {
 	}
 	if want := BranchToOriginal(0x1200); !bytes.Equal(code[28:28+len(want)], want) {
 		t.Fatal("branch stub lost original stack-growth destination")
+	}
+}
+
+func TestRelocateDistantLEA(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		code []byte
+	}{
+		{"AX", []byte{0x66, 0x8d, 0x05, 0x10, 0, 0, 0}},
+		{"EAX", []byte{0x8d, 0x05, 0x10, 0, 0, 0}},
+		{"RAX", []byte{0x48, 0x8d, 0x05, 0x10, 0, 0, 0}},
+		{"R9W", []byte{0x66, 0x44, 0x8d, 0x0d, 0xf0, 0xff, 0xff, 0xff}},
+		{"R9D", []byte{0x44, 0x8d, 0x0d, 0xf0, 0xff, 0xff, 0xff}},
+		{"R9", []byte{0x4c, 0x8d, 0x0d, 0xf0, 0xff, 0xff, 0xff}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			originalInstruction, err := x86asm.Decode(test.code, 64)
+			if err != nil {
+				t.Fatal(err)
+			}
+			code := make([]byte, 128)
+			copy(code, test.code)
+			original := common.PtrOf(code) + 1<<33
+			RelocateBranches(code, original, len(test.code), 32)
+			instruction, err := x86asm.Decode(code, 64)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if instruction.Op != x86asm.MOV || instruction.Len != originalInstruction.Len ||
+				instruction.Args[0] != originalInstruction.Args[0] || instruction.DataSize != originalInstruction.DataSize {
+				t.Fatalf("relocation changed the destination or instruction width: %v -> %v", originalInstruction, instruction)
+			}
+			address := instruction.Args[1].(x86asm.Mem)
+			literal := instruction.Len + int(address.Disp)
+			if address.Base != x86asm.RIP || literal != 32 {
+				t.Fatalf("relocated instruction does not reference its local literal: %v", instruction)
+			}
+			want := original + uintptr(originalInstruction.Len) + uintptr(int32(originalInstruction.Args[1].(x86asm.Mem).Disp))
+			if got := binary.LittleEndian.Uint64(code[literal:]); got != uint64(want) {
+				t.Fatalf("literal contains %#x, want original effective address %#x", got, want)
+			}
+		})
+	}
+}
+
+func TestRelocateNearbyLEA(t *testing.T) {
+	for _, prefix := range [][]byte{nil, {0x64}, {0x65}} {
+		code := common.AllocatePage()
+		defer common.ReleasePage(code)
+		encoding := append(prefix, 0x48, 0x8d, 0x05, 0xf0, 0xff, 0xff, 0xff)
+		copy(code, encoding)
+		original := common.PtrOf(code) + 0x1000
+		RelocateBranches(code, original, len(encoding), 32)
+		instruction, err := x86asm.Decode(code, 64)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if instruction.Op != x86asm.LEA || int32(instruction.Args[1].(x86asm.Mem).Disp) != 0xff0 ||
+			!bytes.Equal(code[:len(encoding)-4], encoding[:len(encoding)-4]) {
+			t.Fatalf("nearby LEA changed its effective address or prefixes: %v", instruction)
+		}
+		if !bytes.Equal(code[32:64], make([]byte, 32)) {
+			t.Fatal("nearby LEA unexpectedly allocated a literal")
+		}
+	}
+}
+
+func TestRelocateLEALiteralsAndBranch(t *testing.T) {
+	code := make([]byte, 128)
+	copy(code, []byte{
+		0x48, 0x8d, 0x05, 0x10, 0, 0, 0, // LEA RAX, [RIP+0x10]
+		0x0f, 0x86, 0xf3, 0x01, 0, 0, // JBE original+0x200
+		0x4c, 0x8d, 0x0d, 0xf0, 0xff, 0xff, 0xff, // LEA R9, [RIP-0x10]
+	})
+	original := common.PtrOf(code) + 1<<33
+	branchBack := BranchToOriginal(original + 20)
+	copy(code[20:], branchBack)
+	RelocateBranches(code, original, 20, 34)
+	if !bytes.Equal(code[20:34], branchBack) {
+		t.Fatal("relocation overwrote the branch back to the original function")
+	}
+	if got := binary.LittleEndian.Uint64(code[34:]); got != uint64(original+23) {
+		t.Fatalf("first literal contains %#x, want %#x", got, original+23)
+	}
+	if want := BranchToOriginal(original + 0x200); !bytes.Equal(code[42:56], want) {
+		t.Fatal("LEA literal overwrote the stack-growth branch stub")
+	}
+	if got := binary.LittleEndian.Uint64(code[56:]); got != uint64(original+4) {
+		t.Fatalf("second literal contains %#x, want %#x", got, original+4)
+	}
+}
+
+func TestRelocateLEARejectsUnsupportedForms(t *testing.T) {
+	for _, test := range []struct {
+		name       string
+		code       []byte
+		stubOffset int
+		message    string
+	}{
+		{"literal bounds", []byte{0x48, 0x8d, 0x05, 0, 0, 0, 0}, 57, "trampoline literals exceed page size"},
+		{"literal overlap", []byte{0x48, 0x8d, 0x05, 0, 0, 0, 0}, 0, "trampoline literals exceed page size"},
+		{"segment prefix", []byte{0x64, 0x48, 0x8d, 0x05, 0, 0, 0, 0}, 32, "cannot relocate PC-relative LEA"},
+		{"address size prefix", []byte{0x67, 0x48, 0x8d, 0x05, 0, 0, 0, 0}, 32, "cannot relocate EIP-relative LEA"},
+		{"data load", []byte{0x48, 0x8b, 0x05, 0, 0, 0, 0}, 32, "PC-relative data reference is out of trampoline range"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			defer func() {
+				failure := recover()
+				if failure == nil || !strings.Contains(fmt.Sprint(failure), test.message) {
+					t.Fatalf("got panic %v, want %q", failure, test.message)
+				}
+			}()
+			code := make([]byte, 64)
+			copy(code, test.code)
+			RelocateBranches(code, common.PtrOf(code)+1<<33, len(test.code), test.stubOffset)
+		})
 	}
 }

--- a/internal/monkey/inst/inst_arm64.go
+++ b/internal/monkey/inst/inst_arm64.go
@@ -1,5 +1,6 @@
 /*
  * Copyright 2022 ByteDance Inc.
+ * Modified in 2026 to preserve closure context in trampoline branches.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,7 +22,7 @@ import "unsafe"
 func BranchTo(to uintptr) (res []byte) {
 	res = append(res, x26MOV(to)...)                     // MOV x26, to // fake
 	res = append(res, []byte{0x40, 0x03, 0x1f, 0xd6}...) // BR x26
-	return
+	return res
 }
 
 // BranchInto create a branch into command
@@ -32,7 +33,7 @@ func BranchInto(to uintptr) (res []byte) {
 	res = append(res, x26MOV(to)...)                     // MOV x26, to // fake
 	res = append(res, []byte{0x53, 0x03, 0x40, 0xf9}...) // LDR x19, [x26]
 	res = append(res, []byte{0x60, 0x02, 0x1f, 0xd6}...) // BR x19
-	return
+	return res
 }
 
 const x26 uint32 = 0b11010
@@ -66,4 +67,15 @@ func x26MOVK(val uintptr, shift int) []byte {
 	res := make([]byte, 4)
 	*(*uint32)(unsafe.Pointer(&res[0])) = inst
 	return res
+}
+
+// BranchToOriginal uses R16, a permanent scratch register in Go's ARM64 ABI,
+// and preserves the closure context in R26 and all argument registers.
+func BranchToOriginal(to uintptr) []byte {
+	code := x26MOV(to)
+	for offset := 0; offset < len(code); offset += instLen {
+		instruction := (*uint32)(unsafe.Pointer(&code[offset]))
+		*instruction = *instruction&^31 | 16
+	}
+	return append(code, 0x00, 0x02, 0x1f, 0xd6) // BR X16
 }

--- a/internal/monkey/inst/inst_arm64_test.go
+++ b/internal/monkey/inst/inst_arm64_test.go
@@ -1,5 +1,6 @@
 /*
  * Copyright 2022 ByteDance Inc.
+ * Modified in 2026 to verify initialization-loop and branch trampolines.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,10 +18,13 @@
 package inst
 
 import (
+	"bytes"
+	"encoding/binary"
 	"fmt"
 	"testing"
 
 	"github.com/smartystreets/goconvey/convey"
+	"golang.org/x/arch/arm64/arm64asm"
 )
 
 func Test_x26MOVZ(t *testing.T) {
@@ -35,4 +39,88 @@ func Test_x26MOVK(t *testing.T) {
 		inst := fmt.Sprintf("%x", x26MOVK(0x123456789abcef01, 1))
 		convey.So(inst, convey.ShouldEqual, "9a57b3f2")
 	})
+}
+
+func TestDisassembleInitializationLoop(t *testing.T) {
+	// The back-edge lies past the former 64-byte read limit and returns
+	// into the 24-byte prefix replaced by the hook.
+	code := make([]byte, 88)
+	for offset := 0; offset < len(code); offset += 4 {
+		binary.LittleEndian.PutUint32(code[offset:], 0xd503201f)
+	}
+	relative := int32((16 - 80) / 4)
+	binary.LittleEndian.PutUint32(code[80:], 0xb5000001|(uint32(relative)&0x7ffff)<<5)
+	binary.LittleEndian.PutUint32(code[84:], 0xd65f03c0)
+	if got := Disassemble(code, 24, true); got != 84 {
+		t.Fatalf("copied prefix length = %d, want 84", got)
+	}
+	t.Run("reject relative address in extended prefix", func(t *testing.T) {
+		binary.LittleEndian.PutUint32(code[32:], 0x90000000)
+		defer func() {
+			if recover() == nil {
+				t.Fatal("expected rejection of an instruction requiring relocation")
+			}
+		}()
+		Disassemble(code, 24, true)
+	})
+}
+
+func TestDisassembleShortUnsafeFunction(t *testing.T) {
+	code := make([]byte, 16)
+	for offset := 0; offset < len(code); offset += 4 {
+		binary.LittleEndian.PutUint32(code[offset:], 0xd503201f)
+	}
+	binary.LittleEndian.PutUint32(code[12:], 0xd65f03c0)
+	if got := Disassemble(code, 24, false); got != 24 {
+		t.Fatalf("unsafe overwrite width = %d, want 24", got)
+	}
+	defer func() {
+		if recover() == nil {
+			t.Fatal("safe patch must reject a short function")
+		}
+	}()
+	Disassemble(code, 24, true)
+}
+
+func TestRelocateStackGuardBranch(t *testing.T) {
+	code := make([]byte, 128)
+	for offset := 0; offset < 24; offset += 4 {
+		binary.LittleEndian.PutUint32(code[offset:], 0xd503201f)
+	}
+	binary.LittleEndian.PutUint32(code, 0x54001009)
+	binary.LittleEndian.PutUint32(code[4:], 0xb5ffffe1)
+	RelocateBranches(code, 0x1000, 24, 44)
+	instruction, err := arm64asm.Decode(code)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := int(instruction.Args[1].(arm64asm.PCRel)); got != 44 {
+		t.Fatalf("guard branch goes to %d, want local stub at 44", got)
+	}
+	if got := binary.LittleEndian.Uint32(code[4:]); got != 0xb5ffffe1 {
+		t.Fatal("branch within copied prefix was changed")
+	}
+	if want := BranchToOriginal(0x1200); !bytes.Equal(code[44:44+len(want)], want) {
+		t.Fatal("branch stub lost original stack-growth destination")
+	}
+}
+
+func TestRelocatePageAddress(t *testing.T) {
+	code := make([]byte, 128)
+	for offset := 0; offset < 24; offset += 4 {
+		binary.LittleEndian.PutUint32(code[offset:], 0xd503201f)
+	}
+	binary.LittleEndian.PutUint32(code, 0x90000000)
+	RelocateBranches(code, 0x12345678, 24, 44)
+	instruction, err := arm64asm.Decode(code)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if instruction.Op != arm64asm.LDR || instruction.Args[0] != arm64asm.X0 {
+		t.Fatalf("address load = %v", instruction)
+	}
+	offset := int(instruction.Args[1].(arm64asm.PCRel))
+	if address := binary.LittleEndian.Uint64(code[offset:]); address != 0x12345000 {
+		t.Fatalf("relocated page address = %#x", address)
+	}
 }

--- a/internal/monkey/linkname/linkname.go
+++ b/internal/monkey/linkname/linkname.go
@@ -23,7 +23,6 @@
 package linkname
 
 import (
-	"reflect"
 	"runtime"
 	"unsafe"
 )
@@ -46,8 +45,13 @@ func init() {
 	textStart := *(*uintptr)(unsafe.Pointer(uintptr(md) + uintptr(textOffset)))
 	funcTabStart := *(**functab)(unsafe.Pointer(uintptr(md) + uintptr(funcTabOffset)))
 	funcTabSize := *(*int)(unsafe.Pointer(uintptr(md) + uintptr(funcTabOffset) + unsafe.Sizeof(uintptr(0))))
-	header := reflect.SliceHeader{
-		Data: uintptr(unsafe.Pointer(funcTabStart)),
+	// Keep the data pointer visible to the garbage collector while building the slice.
+	header := struct {
+		Data *functab
+		Len  int
+		Cap  int
+	}{
+		Data: funcTabStart,
 		Len:  funcTabSize,
 		Cap:  funcTabSize,
 	}
@@ -67,11 +71,12 @@ const (
 
 type functab struct {
 	entryoff uint32
-	funcoff  uint32
+	//lint:ignore U1000 Required by the runtime.functab ABI.
+	funcoff uint32
 }
 
 func getMainModuleData() unsafe.Pointer {
-	var f = getMainModuleData
+	f := getMainModuleData
 	entry := **(**uintptr)(unsafe.Pointer(&f))
 	_, pointer := findfunc(entry)
 	return pointer

--- a/internal/monkey/linkname/linkname.go
+++ b/internal/monkey/linkname/linkname.go
@@ -1,8 +1,9 @@
-//go:build !go1.27
-// +build !go1.27
+//go:build !go1.28
+// +build !go1.28
 
 /*
  * Copyright 2022 ByteDance Inc.
+ * Modified in 2026 to support Go 1.27.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/internal/monkey/mem/write.go
+++ b/internal/monkey/mem/write.go
@@ -1,5 +1,6 @@
 /*
  * Copyright 2022 ByteDance Inc.
+ * Modified in 2026 for Go 1.27 lint compatibility.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -61,5 +62,5 @@ func suspendRuntime() (resume func()) {
 		stwResume()
 		runtime.UnlockOSThread()
 	}
-	return
+	return resume
 }

--- a/internal/monkey/patch.go
+++ b/internal/monkey/patch.go
@@ -1,5 +1,6 @@
 /*
  * Copyright 2022 ByteDance Inc.
+ * Modified in 2026 to bound Go 1.27 trampoline instruction reads.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +19,8 @@ package monkey
 
 import (
 	"reflect"
+	"runtime"
+	"sort"
 
 	"github.com/bytedance/mockey/internal/monkey/common"
 	"github.com/bytedance/mockey/internal/monkey/fn"
@@ -28,9 +31,11 @@ import (
 
 // Patch is a context that holds the address and original codes of the patched function.
 type Patch struct {
-	size int
-	code []byte
-	base uintptr
+	code      []byte
+	base      uintptr
+	original  []byte
+	entryCode []byte
+	hook      reflect.Value // Machine-code pointers do not keep the hook closure alive for GC.
 }
 
 // Base returns the address of the patched function.
@@ -40,7 +45,7 @@ func (p *Patch) Base() uintptr {
 
 // Unpatch restores the patched function to the original function.
 func (p *Patch) Unpatch() {
-	mem.WriteWithSTW(p.base, p.code[:p.size])
+	mem.WriteWithSTW(p.base, p.original)
 	common.ReleasePage(p.code)
 }
 
@@ -51,30 +56,86 @@ func PatchValue(target, hook, proxy reflect.Value, unsafe bool) *Patch {
 	tool.Assert(proxy.Kind() == reflect.Ptr, "'%v' is not a function pointer", proxy.Kind())
 
 	targetAddr := target.Pointer()
-	// The first few bytes of the target function code
-	const bufSize = 64
-	targetCodeBuf := common.BytesOf(targetAddr, bufSize)
+	// Bound instruction reads by the runtime function table. ARM64 also needs
+	// to inspect backward branches after the prefix to keep initialization
+	// loops together when constructing the Origin trampoline.
+	codeSize := targetCodeSize(targetAddr)
+	targetCodeBuf := common.BytesOf(targetAddr, codeSize)
 	// construct the branch instruction, i.e. jump to the hook function
 	hookCode := inst.BranchInto(common.PtrAt(hook))
 	// construct the proxy code
 	proxyCode := common.AllocatePage()
+	installed := false
+	defer func() {
+		if !installed {
+			common.ReleasePage(proxyCode)
+		}
+	}()
 	tool.DebugPrintf("PatchValue: target addr(0x%x), proxy addr(%p), hook code len(%v)\n", targetAddr, &proxyCode[0], len(hookCode))
 	// search the cutting point of the target code, i.e. the minimum length of full instructions that is longer than the hookCode
 	cuttingIdx := inst.Disassemble(targetCodeBuf, len(hookCode), !unsafe)
+	// MockUnsafe deliberately permits a hook to overlap a short function's
+	// boundary. Save exactly the bytes it will overwrite so Unpatch restores
+	// them, while keeping the instruction scan within the function itself.
+	if cuttingIdx > len(targetCodeBuf) {
+		tool.Assert(unsafe, "function is too short to patch")
+		targetCodeBuf = common.BytesOf(targetAddr, cuttingIdx)
+	}
 	// save the original code before the cutting point
+	branchBack := inst.BranchToOriginal(targetAddr + uintptr(cuttingIdx))
+	tool.Assert(cuttingIdx+len(branchBack) <= len(proxyCode), "initialization loop is too large to patch")
 	copy(proxyCode, targetCodeBuf[:cuttingIdx])
 	// construct the branch instruction, i.e. jump to the cutting point
-	copy(proxyCode[cuttingIdx:], inst.BranchTo(targetAddr+uintptr(cuttingIdx)))
+	copy(proxyCode[cuttingIdx:], branchBack)
+	original := append([]byte(nil), targetCodeBuf[:cuttingIdx]...)
+	relocationEnd := cuttingIdx
+	if relocationEnd > codeSize {
+		relocationEnd = codeSize
+	}
+	inst.RelocateBranches(proxyCode, targetAddr, relocationEnd, cuttingIdx+len(branchBack))
 	// inject the proxy code to the proxy function
 	fn.InjectInto(proxy, proxyCode)
 	// replace target function codes before the cutting point
 	mem.WriteWithSTW(targetAddr, hookCode)
+	installed = true
 
-	return &Patch{base: targetAddr, code: proxyCode, size: cuttingIdx}
+	return &Patch{base: targetAddr, code: proxyCode, original: original, entryCode: hookCode, hook: hook}
 }
 
 func PatchFunc(fn, hook, proxy interface{}, unsafe bool) *Patch {
 	vv := reflect.ValueOf(fn)
 	tool.Assert(vv.Kind() == reflect.Func, "'%v' is not a function", fn)
 	return PatchValue(vv, reflect.ValueOf(hook), reflect.ValueOf(proxy), unsafe)
+}
+
+// targetCodeSize queries metadata rather than reading past a function while
+// looking for its end. runtime.FuncForPC includes dynamically loaded modules,
+// unlike the main module's function list used for symbol-name discovery.
+func targetCodeSize(entry uintptr) int {
+	function := runtime.FuncForPC(entry)
+	tool.Assert(function != nil && function.Entry() == entry, "target function bounds not found")
+	outside := func(offset int) bool {
+		function := runtime.FuncForPC(entry + uintptr(offset))
+		return function == nil || function.Entry() != entry
+	}
+	limit := 64
+	if runtime.GOARCH == "arm64" {
+		for !outside(limit) {
+			tool.Assert(limit < 1<<24, "target function is too large to analyze")
+			limit *= 2
+		}
+	}
+	return sort.Search(limit, outside)
+}
+
+// IsCurrent reports whether this patch owns the function's current entry.
+// Older layered patches remain callable through proxies but do not own it.
+func (p *Patch) IsCurrent() bool {
+	current := common.BytesOf(p.base, len(p.entryCode))
+	for index, instruction := range p.entryCode {
+		if current[index] != instruction {
+			return false
+		}
+	}
+	return true
 }

--- a/internal/monkey/patch_1_17_test.go
+++ b/internal/monkey/patch_1_17_test.go
@@ -3,6 +3,7 @@
 
 /*
  * Copyright 2022 ByteDance Inc.
+ * Modified in 2026 for Go 1.27 lint compatibility.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,7 +31,7 @@ func UnsafeTarget() {}
 func TestPatchUnsafeFunc(t *testing.T) {
 	Convey("TestPatchUnsafeFunc", t, func() {
 		var proxy func()
-		var hook = func() { panic("good") }
+		hook := func() { panic("good") }
 		Convey("normal", func() {
 			So(func() { PatchFunc(UnsafeTarget, hook, &proxy, false) }, ShouldPanicWith, "function is too short to patch")
 		})

--- a/internal/monkey/patch_test.go
+++ b/internal/monkey/patch_test.go
@@ -1,5 +1,6 @@
 /*
  * Copyright 2022 ByteDance Inc.
+ * Modified in 2026 to verify hook lifetime during garbage collection.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +19,7 @@ package monkey
 
 import (
 	"reflect"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -72,5 +74,34 @@ func TestPatchFunc(t *testing.T) {
 			patch.Unpatch()
 			So(Target("anything"), ShouldEqual, "anything")
 		})
+	})
+}
+
+func TestPatchKeepsHookAlive(t *testing.T) {
+	collected := make(chan struct{}, 1)
+	var proxy func(string) string
+	patch := PatchValue(reflect.ValueOf(Target), temporaryReflectHook(collected), reflect.ValueOf(&proxy), false)
+	defer patch.Unpatch()
+	for i := 0; i < 3; i++ {
+		runtime.GC()
+	}
+	select {
+	case <-collected:
+		t.Fatal("active patch lost the hook closure's GC root")
+	default:
+	}
+	if got := Target("original"); got != "retained hook" {
+		t.Fatalf("hook result = %q", got)
+	}
+}
+
+func temporaryReflectHook(collected chan<- struct{}) reflect.Value {
+	payload := &struct {
+		text    string
+		padding [64]byte
+	}{text: "retained hook"}
+	runtime.SetFinalizer(payload, func(interface{}) { collected <- struct{}{} })
+	return reflect.MakeFunc(reflect.TypeOf(Target), func([]reflect.Value) []reflect.Value {
+		return []reflect.Value{reflect.ValueOf(payload.text)}
 	})
 }

--- a/internal/monkey/stw/stw_1_23.go
+++ b/internal/monkey/stw/stw_1_23.go
@@ -1,8 +1,9 @@
-//go:build go1.23 && !go1.27
-// +build go1.23,!go1.27
+//go:build go1.23 && !go1.28
+// +build go1.23,!go1.28
 
 /*
  * Copyright 2022 ByteDance Inc.
+ * Modified in 2026 to support Go 1.27.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/internal/monkey/stw/stw_1_23.go
+++ b/internal/monkey/stw/stw_1_23.go
@@ -40,10 +40,14 @@ type stwReason uint8
 // worldStop provides context from the stop-the-world required by the
 // start-the-world.
 type worldStop struct {
-	reason           stwReason
-	startedStopping  int64
+	//lint:ignore U1000 Required by the runtime.worldStop ABI.
+	reason stwReason
+	//lint:ignore U1000 Required by the runtime.worldStop ABI.
+	startedStopping int64
+	//lint:ignore U1000 Required by the runtime.worldStop ABI.
 	finishedStopping int64
-	stoppingCPUTime  int64
+	//lint:ignore U1000 Required by the runtime.worldStop ABI.
+	stoppingCPUTime int64
 }
 
 var (

--- a/internal/monkey/sysmon/schedt_1_26.go
+++ b/internal/monkey/sysmon/schedt_1_26.go
@@ -1,8 +1,9 @@
-//go:build go1.26 && !go1.27
-// +build go1.26,!go1.27
+//go:build go1.26 && !go1.28
+// +build go1.26,!go1.28
 
 /*
  * Copyright 2022 ByteDance Inc.
+ * Modified in 2026 to support Go 1.27.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/internal/monkey/sysmon/suspend.go
+++ b/internal/monkey/sysmon/suspend.go
@@ -3,6 +3,7 @@
 
 /*
  * Copyright 2022 ByteDance Inc.
+ * Modified in 2026 to support Go 1.27.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -40,10 +41,9 @@ func SuspendSysmon() (resume func()) {
 	usleep(100)
 
 	// Construct resume function
-	resume = func() {
+	return func() {
 		unlock(sysmonLockPtr)
 	}
-	return
 }
 
 // getSysmonLockOffset Get the sysmon lock offset for the current Go version

--- a/internal/monkey/sysmon/suspend_1_23.go
+++ b/internal/monkey/sysmon/suspend_1_23.go
@@ -3,7 +3,7 @@
 
 /*
  * Copyright 2022 ByteDance Inc.
- * Modified in 2026 to support Go 1.27.
+ * Modified in 2026 to support Go 1.27 and the Windows sleep ABI.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,6 +22,7 @@ package sysmon
 
 import (
 	"reflect"
+	"runtime"
 	"unsafe"
 
 	"github.com/bytedance/mockey/internal/monkey/fn"
@@ -30,15 +31,21 @@ import (
 
 func init() {
 	usleepPC := linkname.FuncPCForName("runtime.usleep")
-	usleep = func(usec uint32) { usleepTrampoline(usec, usleepPC) }
+	if runtime.GOOS == "windows" {
+		// Windows implements usleep as ordinary Go code with register arguments.
+		// The stack-argument trampoline can otherwise pass an arbitrary delay,
+		// particularly when race instrumentation changes the argument registers.
+		usleep = fn.MakeFunc(reflect.TypeOf(usleep), usleepPC).Interface().(func(uint32))
+	} else {
+		usleep = func(usec uint32) { usleepTrampoline(usec, usleepPC) }
+	}
 	lockPC := linkname.FuncPCForName("runtime.lock")
 	lock = fn.MakeFunc(reflect.TypeOf(lock), lockPC).Interface().(func(unsafe.Pointer))
 	unlockPC := linkname.FuncPCForName("runtime.unlock")
 	unlock = fn.MakeFunc(reflect.TypeOf(unlock), unlockPC).Interface().(func(unsafe.Pointer))
 }
 
-// usleepTrampoline a trampoline for the function `runtime.usleep`. `runtime.usleep` is marked with the special tag
-// `go:cgo_unsafe_args`, whose input parameters are passed via the stack instead of registers. Therefore, directly
-// injecting the program counter value of the target function into other user-defined functions will result in undefined
-// behavior due to argument mismatch.
+// usleepTrampoline calls the stack-argument runtime.usleep used outside Windows.
+// This includes assembly implementations and functions marked go:cgo_unsafe_args.
+// Windows uses the ordinary Go register ABI and is bound directly above.
 func usleepTrampoline(usec uint32, pc uintptr)

--- a/internal/monkey/sysmon/suspend_1_23.go
+++ b/internal/monkey/sysmon/suspend_1_23.go
@@ -1,8 +1,9 @@
-//go:build !mockey_disable_ss && go1.23 && !go1.27
-// +build !mockey_disable_ss,go1.23,!go1.27
+//go:build !mockey_disable_ss && go1.23 && !go1.28
+// +build !mockey_disable_ss,go1.23,!go1.28
 
 /*
  * Copyright 2022 ByteDance Inc.
+ * Modified in 2026 to support Go 1.27.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/internal/monkey/sysmon/suspend_1_23_amd64.s
+++ b/internal/monkey/sysmon/suspend_1_23_amd64.s
@@ -1,8 +1,9 @@
-//go:build !mockey_disable_ss && go1.23 && !go1.27
-// +build !mockey_disable_ss,go1.23,!go1.27
+//go:build !mockey_disable_ss && go1.23 && !go1.28
+// +build !mockey_disable_ss,go1.23,!go1.28
 
 /*
  * Copyright 2022 ByteDance Inc.
+ * Modified in 2026 to support Go 1.27.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/internal/monkey/sysmon/suspend_1_23_arm64.s
+++ b/internal/monkey/sysmon/suspend_1_23_arm64.s
@@ -1,8 +1,9 @@
-//go:build !mockey_disable_ss && go1.23 && !go1.27
-// +build !mockey_disable_ss,go1.23,!go1.27
+//go:build !mockey_disable_ss && go1.23 && !go1.28
+// +build !mockey_disable_ss,go1.23,!go1.28
 
 /*
  * Copyright 2022 ByteDance Inc.
+ * Modified in 2026 to support Go 1.27.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/internal/monkey/sysmon/suspend_windows_test.go
+++ b/internal/monkey/sysmon/suspend_windows_test.go
@@ -1,0 +1,65 @@
+//go:build windows && (amd64 || arm64) && !mockey_disable_ss && go1.23 && !go1.28
+// +build windows
+// +build amd64 arm64
+// +build !mockey_disable_ss
+// +build go1.23
+// +build !go1.28
+
+/*
+ * Copyright 2026 ByteDance Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package sysmon
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"testing"
+	"time"
+)
+
+func TestWindowsUsleepDuration(t *testing.T) {
+	const childMarker = "MOCKEY_TEST_WINDOWS_USLEEP"
+	if os.Getenv(childMarker) == "1" {
+		started := time.Now()
+		for index := 0; index < 3; index++ {
+			usleep(20000)
+		}
+		elapsed := time.Since(started)
+		if elapsed < 30*time.Millisecond || elapsed > 2*time.Second {
+			t.Fatalf("three 20ms runtime sleeps took %s", elapsed)
+		}
+		return
+	}
+
+	// A mismatched register can turn a short sleep into minutes while blocking
+	// the runtime thread. Bound the entire child process, including race builds.
+	executable, err := os.Executable()
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	command := exec.CommandContext(ctx, executable, "-test.run=^TestWindowsUsleepDuration$")
+	command.Env = append(os.Environ(), childMarker+"=1")
+	output, err := command.CombinedOutput()
+	if ctx.Err() != nil {
+		t.Fatalf("runtime.usleep did not finish within 10s: %s", output)
+	}
+	if err != nil {
+		t.Fatalf("runtime.usleep subprocess failed: %v\n%s", err, output)
+	}
+}

--- a/internal/tool/goroutine_1_25.go
+++ b/internal/tool/goroutine_1_25.go
@@ -1,8 +1,9 @@
-//go:build go1.25 && !go1.27
-// +build go1.25,!go1.27
+//go:build go1.25 && !go1.28
+// +build go1.25,!go1.28
 
 /*
  * Copyright 2022 ByteDance Inc.
+ * Modified in 2026 to support Go 1.27.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/internal/tool/reflect.go
+++ b/internal/tool/reflect.go
@@ -1,5 +1,6 @@
 /*
  * Copyright 2022 ByteDance Inc.
+ * Modified in 2026 for Go 1.27 lint compatibility.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -57,7 +58,7 @@ func NewFuncTypeByInsertIn(ft reflect.Type, newInTypes ...reflect.Type) reflect.
 	return reflect.FuncOf(inTypes, outTypes, ft.IsVariadic())
 }
 
-func NewFuncTypeByReplaceIn(ft reflect.Type, newInType reflect.Type, newInIndex int) reflect.Type {
+func NewFuncTypeByReplaceIn(ft, newInType reflect.Type, newInIndex int) reflect.Type {
 	inTypes := make([]reflect.Type, ft.NumIn())
 	for i := 0; i < ft.NumIn(); i++ {
 		if i == newInIndex {
@@ -76,7 +77,7 @@ func NewFuncTypeByReplaceIn(ft reflect.Type, newInType reflect.Type, newInIndex 
 func MakeEmptyInArgs(ft reflect.Type) []reflect.Value {
 	args := make([]reflect.Value, ft.NumIn())
 	for i := range args {
-		args[i] = MakeEmtpy(ft.In(i))
+		args[i] = MakeEmpty(ft.In(i))
 	}
 	return args
 }
@@ -84,12 +85,12 @@ func MakeEmptyInArgs(ft reflect.Type) []reflect.Value {
 func MakeEmptyOutArgs(ft reflect.Type) []reflect.Value {
 	args := make([]reflect.Value, ft.NumOut())
 	for i := range args {
-		args[i] = MakeEmtpy(ft.Out(i))
+		args[i] = MakeEmpty(ft.Out(i))
 	}
 	return args
 }
 
-func MakeEmtpy(typ reflect.Type) reflect.Value {
+func MakeEmpty(typ reflect.Type) reflect.Value {
 	switch typ.Kind() {
 	case reflect.Ptr:
 		return reflect.New(typ.Elem())

--- a/internal/unsafereflect/name_1_17.go
+++ b/internal/unsafereflect/name_1_17.go
@@ -44,11 +44,11 @@ func (n name) readVarint(off int) (int, int) {
 
 func (n name) name() (s string) {
 	if n.bytes == nil {
-		return
+		return s
 	}
 	i, l := n.readVarint(1)
 	hdr := (*_String)(unsafe.Pointer(&s))
 	hdr.Data = unsafe.Pointer(n.data(1+i, "non-empty string"))
 	hdr.Len = l
-	return
+	return s
 }

--- a/internal/unsafereflect/name_1_17.go
+++ b/internal/unsafereflect/name_1_17.go
@@ -1,8 +1,9 @@
-//go:build go1.17 && !go1.27
-// +build go1.17,!go1.27
+//go:build go1.17 && !go1.28
+// +build go1.17,!go1.28
 
 /*
  * Copyright 2023 ByteDance Inc.
+ * Modified in 2026 to support Go 1.27.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/internal/unsafereflect/name_below_1_17.go
+++ b/internal/unsafereflect/name_below_1_17.go
@@ -3,6 +3,7 @@
 
 /*
  * Copyright 2023 ByteDance Inc.
+ * Modified in 2026 for Go 1.27 lint compatibility.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,7 +31,7 @@ type name struct {
 
 func (n name) name() (s string) {
 	if n.bytes == nil {
-		return
+		return s
 	}
 	b := (*[4]byte)(unsafe.Pointer(n.bytes))
 

--- a/mock.go
+++ b/mock.go
@@ -1,5 +1,6 @@
 /*
  * Copyright 2022 ByteDance Inc.
+ * Modified in 2026 to distinguish original-function stack-growth retries.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -218,7 +219,7 @@ func (mocker *Mocker) build() {
 	mocker.proxy = reflect.New(mocker.builder.runtimeTargetType())
 
 	originExec = func(args []reflect.Value) []reflect.Value {
-		return tool.ReflectCall(mocker.proxy.Elem(), args)
+		return mocker.callOriginal(mocker.proxy.Elem(), args)
 	}
 
 	if originPtr := mocker.builder.originPtr; originPtr != nil {
@@ -226,7 +227,7 @@ func (mocker *Mocker) build() {
 		originType := reflect.TypeOf(originPtr).Elem()
 		adapter := mocker.builder.analyzer.ReversedInputAdapter("origin", originType)
 		origin.Set(reflect.MakeFunc(originType, func(args []reflect.Value) []reflect.Value {
-			return tool.ReflectCall(mocker.proxy.Elem(), adapter(args, extraArgsGetter()))
+			return mocker.callOriginal(mocker.proxy.Elem(), adapter(args, extraArgsGetter()))
 		}))
 	}
 
@@ -253,6 +254,9 @@ func (mocker *Mocker) build() {
 	}
 
 	mockerHook := reflect.MakeFunc(mocker.builder.runtimeTargetType(), func(args []reflect.Value) []reflect.Value {
+		if invocation := mocker.originalStackRetry(); invocation != nil {
+			return mocker.resumeOriginal(invocation, args)
+		}
 		if mocker.builder.originPtr != nil {
 			// Origin call need extra args, which only can be obtained during the execution of mockerHook.
 			extraArgsGetter = func() []reflect.Value { return args }

--- a/mock_benchmark_test.go
+++ b/mock_benchmark_test.go
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2026 ByteDance Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package mockey
+
+import (
+	"sync/atomic"
+	"testing"
+)
+
+var benchmarkCallResult int64
+
+//go:noinline
+func benchmarkCallTarget(value int) int {
+	return value + 1
+}
+
+// BenchmarkMockCall excludes patch construction and removal. Run with
+// -gcflags="all=-N -l", as for the test suite. Origin measures calls through the
+// saved original function directly, isolating its bookkeeping from a decorator.
+func BenchmarkMockCall(b *testing.B) {
+	b.Run("Direct", func(b *testing.B) {
+		result := 0
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			result = benchmarkCallTarget(i)
+		}
+		b.StopTimer()
+		benchmarkCallResult = int64(result)
+	})
+	b.Run("Return", func(b *testing.B) {
+		mock := Mock(benchmarkCallTarget).Return(7).Build()
+		defer mock.UnPatch()
+		if got := benchmarkCallTarget(41); got != 7 {
+			b.Fatalf("mock returned %d, want 7", got)
+		}
+		result := 0
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			result = benchmarkCallTarget(i)
+		}
+		b.StopTimer()
+		benchmarkCallResult = int64(result)
+	})
+	for _, parallel := range []bool{false, true} {
+		name := "Origin"
+		if parallel {
+			name = "OriginParallel"
+		}
+		b.Run(name, func(b *testing.B) {
+			var original func(int) int
+			mock := Mock(benchmarkCallTarget).Origin(&original).Return(7).Build()
+			defer mock.UnPatch()
+			if got := benchmarkCallTarget(41); got != 7 {
+				b.Fatalf("mock returned %d, want 7", got)
+			}
+			if got := original(41); got != 42 {
+				b.Fatalf("original returned %d, want 42", got)
+			}
+			b.ReportAllocs()
+			b.ResetTimer()
+			if parallel {
+				b.RunParallel(func(pb *testing.PB) {
+					result := 0
+					for pb.Next() {
+						result = original(result & 255)
+					}
+					atomic.AddInt64(&benchmarkCallResult, int64(result))
+				})
+			} else {
+				result := 0
+				for i := 0; i < b.N; i++ {
+					result = original(i)
+				}
+				benchmarkCallResult = int64(result)
+			}
+			b.StopTimer()
+		})
+	}
+}

--- a/mock_generic_methods_go1_27_test.go
+++ b/mock_generic_methods_go1_27_test.go
@@ -1,0 +1,210 @@
+//go:build go1.27
+// +build go1.27
+
+/*
+ * Copyright 2026 ByteDance Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package mockey
+
+import (
+	"math/rand/v2"
+	"reflect"
+	"testing"
+)
+
+type methodReceiver127 struct {
+	label  string
+	number int
+}
+
+func (r methodReceiver127) Echo[T any](value T) T         { return value }
+func (r *methodReceiver127) PointerEcho[T any](value T) T { return value }
+
+type parameterizedReceiver127[T any] struct{ value T }
+
+func (r parameterizedReceiver127[T]) Echo[U any](value U) U         { return value }
+func (r *parameterizedReceiver127[T]) PointerEcho[U any](value U) U { return value }
+func (r *parameterizedReceiver127[T]) Pair[U any](value U) (T, U)   { return r.value, value }
+
+type emptyMethodReceiver127 struct{}
+
+func (r emptyMethodReceiver127) Zero[T any]() T { var value T; return value }
+
+func genericMethodExpression127[T any]() func(*parameterizedReceiver127[T], int) int {
+	return (*parameterizedReceiver127[T]).PointerEcho[int]
+}
+
+type largeMethodValue127 struct{ values [40]string }
+
+func (r largeMethodValue127) Echo[T any](value T) (largeMethodValue127, T) {
+	return r, value
+}
+
+func (r methodReceiver127) Variadic[T any](prefix T, values ...T) []T {
+	return append([]T{prefix}, values...)
+}
+
+func TestGenericMethodExpressions127(t *testing.T) {
+	t.Run("value receiver arguments and origin", func(t *testing.T) {
+		receiver := methodReceiver127{label: "receiver", number: 7}
+		var origin func(methodReceiver127, int) int
+		mock := Mock(methodReceiver127.Echo[int]).Origin(&origin).To(func(got methodReceiver127, value int) int {
+			if got != receiver || value != 3 {
+				t.Fatalf("got receiver %v, argument %d", got, value)
+			}
+			return origin(got, value+got.number)
+		}).Build()
+		defer mock.UnPatch()
+		if got := receiver.Echo[int](3); got != 10 {
+			t.Fatalf("got %d, want 10", got)
+		}
+		if got := methodReceiver127.Echo[int](receiver, 3); got != 10 {
+			t.Fatalf("method expression got %d, want 10", got)
+		}
+	})
+	t.Run("pointer receiver without receiver hook argument", func(t *testing.T) {
+		receiver := &methodReceiver127{number: 7}
+		var origin func(int) int
+		mock := Mock((*methodReceiver127).PointerEcho[int]).Origin(&origin).To(func(value int) int { return origin(value + 1) }).Build()
+		defer mock.UnPatch()
+		if got := receiver.PointerEcho[int](3); got != 4 {
+			t.Fatalf("got %d, want 4", got)
+		}
+	})
+	t.Run("receiver and method type parameters", func(t *testing.T) {
+		receiver := parameterizedReceiver127[string]{value: "a"}
+		mock := Mock(parameterizedReceiver127[string].Echo[int]).To(func(got parameterizedReceiver127[string], value int) int {
+			if got != receiver {
+				t.Fatalf("got receiver %v", got)
+			}
+			return value + 10
+		}).Build()
+		defer mock.UnPatch()
+		if got := receiver.Echo[int](3); got != 13 {
+			t.Fatalf("got %d, want 13", got)
+		}
+	})
+	t.Run("dictionary separates instantiations sharing a shape", func(t *testing.T) {
+		type namedInt int
+		type namedString string
+		receiver := &parameterizedReceiver127[string]{value: "a"}
+		mock := Mock((*parameterizedReceiver127[string]).PointerEcho[int]).Return(99).Build()
+		defer mock.UnPatch()
+		if got := receiver.PointerEcho[int](3); got != 99 {
+			t.Fatalf("got %d, want 99", got)
+		}
+		if got := receiver.PointerEcho[namedInt](3); got != 3 {
+			t.Fatalf("other method instantiation got %d", got)
+		}
+		other := &parameterizedReceiver127[namedString]{value: "a"}
+		if got := other.PointerEcho[int](3); got != 3 {
+			t.Fatalf("other receiver instantiation got %d", got)
+		}
+	})
+	t.Run("large receiver arguments and results", func(t *testing.T) {
+		receiver := largeMethodValue127{}
+		receiver.values[0], receiver.values[39] = "receiver first", "receiver last"
+		argument := largeMethodValue127{}
+		argument.values[0], argument.values[39] = "argument first", "argument last"
+		var origin func(largeMethodValue127, largeMethodValue127) (largeMethodValue127, largeMethodValue127)
+		mock := Mock(largeMethodValue127.Echo[largeMethodValue127]).Origin(&origin).To(func(got, value largeMethodValue127) (largeMethodValue127, largeMethodValue127) {
+			if got != receiver || value != argument {
+				t.Fatal("large receiver or argument corrupted")
+			}
+			got.values[1] = "mocked"
+			return origin(got, value)
+		}).Build()
+		defer mock.UnPatch()
+		gotReceiver, gotArgument := receiver.Echo[largeMethodValue127](argument)
+		receiver.values[1] = "mocked"
+		if gotReceiver != receiver || gotArgument != argument {
+			t.Fatal("large result corrupted")
+		}
+	})
+	t.Run("variadic arguments", func(t *testing.T) {
+		var origin func(methodReceiver127, string, ...string) []string
+		mock := Mock(methodReceiver127.Variadic[string]).Origin(&origin).To(func(r methodReceiver127, prefix string, values ...string) []string {
+			return origin(r, "mock "+prefix, values...)
+		}).Build()
+		defer mock.UnPatch()
+		if got := (methodReceiver127{}).Variadic[string]("prefix", "a", "b"); !reflect.DeepEqual(got, []string{"mock prefix", "a", "b"}) {
+			t.Fatalf("got %v", got)
+		}
+	})
+}
+
+func TestGenericPointerMethodValues127(t *testing.T) {
+	receiver := &parameterizedReceiver127[string]{value: "receiver"}
+	method := receiver.Pair[int]
+	var origin func(int) (string, int)
+	mock := Mock(method).Origin(&origin).To(func(value int) (string, int) { return origin(value + 10) }).Build()
+	defer mock.UnPatch()
+	if gotReceiver, got := method(3); gotReceiver != "receiver" || got != 13 {
+		t.Fatalf("method value got %q, %d", gotReceiver, got)
+	}
+	other := &parameterizedReceiver127[string]{value: "other receiver"}
+	if gotReceiver, got := other.Pair[int](3); gotReceiver != "other receiver" || got != 13 {
+		t.Fatalf("direct method got %q, %d", gotReceiver, got)
+	}
+}
+
+func TestGenericMethodEmptyReceiver127(t *testing.T) {
+	mock := Mock(emptyMethodReceiver127.Zero[int]).Return(42).Build()
+	defer mock.UnPatch()
+	if got := (emptyMethodReceiver127{}).Zero[int](); got != 42 {
+		t.Fatalf("got %d, want 42", got)
+	}
+}
+
+func TestGenericMethodDynamicDictionary127(t *testing.T) {
+	mock := Mock(genericMethodExpression127[string]()).Return(42).Build()
+	defer mock.UnPatch()
+	if got := (&parameterizedReceiver127[string]{}).PointerEcho[int](3); got != 42 {
+		t.Fatalf("got %d, want 42", got)
+	}
+}
+
+func TestGenericMethodUnsupportedValue127(t *testing.T) {
+	defer func() {
+		if recover() == nil {
+			t.Fatal("bound value method must fail before patching; use a method expression")
+		}
+	}()
+	Mock((methodReceiver127{}).Echo[int])
+}
+
+func TestGenericMethodUserClosure127(t *testing.T) {
+	// A normal closure can have exactly the same call graph and signature as
+	// the generated method-expression wrapper; it must not patch the method.
+	wrapper := func(r methodReceiver127, value int) int { return r.Echo[int](value) }
+	mock := Mock(wrapper).Return(99).Build()
+	defer mock.UnPatch()
+	if got := wrapper(methodReceiver127{}, 3); got != 99 {
+		t.Fatalf("closure got %d, want 99", got)
+	}
+	if got := (methodReceiver127{}).Echo[int](3); got != 3 {
+		t.Fatalf("unmocked method got %d, want 3", got)
+	}
+}
+
+func TestGenericStandardLibraryMethod127(t *testing.T) {
+	generator := rand.New(rand.NewPCG(1, 2))
+	mock := Mock((*rand.Rand).N[int]).Return(42).Build()
+	defer mock.UnPatch()
+	if got := generator.N[int](100); got != 42 {
+		t.Fatalf("Rand.N[int] = %d, want 42", got)
+	}
+}

--- a/mock_generics_test.go
+++ b/mock_generics_test.go
@@ -3,6 +3,7 @@
 
 /*
  * Copyright 2022 ByteDance Inc.
+ * Modified in 2026 for Go 1.27 lint compatibility.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -130,7 +131,7 @@ func TestGeneric(t *testing.T) {
 		})
 		PatchConvey("origin", func() {
 			PatchConvey("func", func() {
-				var origin = sum[float64]
+				origin := sum[float64]
 				decorator := func(a, b float64) float64 {
 					return origin(a, b) + 1
 				}
@@ -139,7 +140,7 @@ func TestGeneric(t *testing.T) {
 			})
 
 			PatchConvey("method", func() {
-				var origin = generic[string].Value2
+				origin := generic[string].Value2
 				decorator := func(a generic[string], hint string) string {
 					return "decorated " + origin(a, hint)
 				}
@@ -286,8 +287,9 @@ func TestGenericArgValues(t *testing.T) {
 					convey.So(info.UsedParamType(3), convey.ShouldEqual, reflect.TypeOf(r1))
 					convey.So(info.UsedParamType(4), convey.ShouldEqual, reflect.TypeOf(r2))
 					convey.So(info.UsedParamType(5), convey.ShouldEqual, reflect.TypeOf(r3))
-					return
-				}).Build()
+					return r1, r2, r3
+				},
+			).Build()
 			target(1, 2, "3")
 		})
 	})

--- a/mock_option.go
+++ b/mock_option.go
@@ -1,5 +1,6 @@
 /*
  * Copyright 2022 ByteDance Inc.
+ * Modified in 2026 to satisfy the current formatter.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,12 +30,12 @@ func OptUnsafe(o *mockOption) {
 }
 
 func OptGeneric(o *mockOption) {
-	var t = true
+	t := true
 	o.generic = &t
 }
 
 func OptMethod(o *mockOption) {
-	var t = true
+	t := true
 	o.method = &t
 }
 

--- a/mock_original.go
+++ b/mock_original.go
@@ -1,0 +1,143 @@
+/*
+ * Copyright 2026 ByteDance Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package mockey
+
+import (
+	"reflect"
+	"runtime"
+	"sync"
+	"sync/atomic"
+
+	monkeyFn "github.com/bytedance/mockey/internal/monkey/fn"
+	"github.com/bytedance/mockey/internal/tool"
+)
+
+type originalInvocation struct {
+	owner  *Mocker
+	proxy  reflect.Value
+	parent *originalInvocation
+}
+
+var originalCalls = struct {
+	sync.Mutex
+	byGoroutine map[int64]*originalInvocation
+}{byGoroutine: make(map[int64]*originalInvocation)}
+
+var (
+	originalCallCount int64
+	callOriginalEntry = reflect.ValueOf((*Mocker).callOriginal).Pointer()
+)
+
+// callOriginal provides a recognizable caller frame and tracks the exact
+// proxy being invoked. The per-goroutine stack only disambiguates retries;
+// it does not suppress recursive calls made by an original function.
+//
+//go:noinline
+func (mocker *Mocker) callOriginal(proxy reflect.Value, args []reflect.Value) []reflect.Value {
+	goroutine := tool.GetGoroutineID()
+	originalCalls.Lock()
+	invocation := &originalInvocation{owner: mocker, proxy: proxy, parent: originalCalls.byGoroutine[goroutine]}
+	originalCalls.byGoroutine[goroutine] = invocation
+	originalCalls.Unlock()
+	atomic.AddInt64(&originalCallCount, 1)
+	defer func() {
+		originalCalls.Lock()
+		if invocation.parent == nil {
+			delete(originalCalls.byGoroutine, goroutine)
+		} else {
+			originalCalls.byGoroutine[goroutine] = invocation.parent
+		}
+		originalCalls.Unlock()
+		atomic.AddInt64(&originalCallCount, -1)
+	}()
+	return tool.ReflectCall(proxy, args)
+}
+
+// originalStackRetry recognizes only a stack-growth retry that returns from
+// an original proxy straight into the currently installed entry hook. A real
+// recursive call has its original body (or user callback) as the nearer caller.
+//
+//go:noinline
+func (mocker *Mocker) originalStackRetry() *originalInvocation {
+	if atomic.LoadInt64(&originalCallCount) == 0 {
+		return nil
+	}
+	goroutine := tool.GetGoroutineID()
+	originalCalls.Lock()
+	invocation := originalCalls.byGoroutine[goroutine]
+	originalCalls.Unlock()
+	if invocation == nil || mocker.patch == nil {
+		return nil
+	}
+	if invocation.owner.builder.analyzer.RuntimeTargetValue().Pointer() != mocker.builder.analyzer.RuntimeTargetValue().Pointer() {
+		return nil
+	}
+	if !mocker.patch.IsCurrent() {
+		return nil
+	}
+	var pcs [32]uintptr
+	// Skip runtime.Callers, this detector, and the immediate mock hook.
+	count := runtime.Callers(3, pcs[:])
+	frames := runtime.CallersFrames(pcs[:count])
+	for {
+		frame, more := frames.Next()
+		if !originalCallBridge(frame.Function) {
+			if frame.Entry == callOriginalEntry {
+				return invocation
+			}
+			return nil
+		}
+		if !more {
+			return nil
+		}
+	}
+}
+
+func originalCallBridge(name string) bool {
+	if len(name) >= len(".abi0") && name[len(name)-len(".abi0"):] == ".abi0" {
+		name = name[:len(name)-len(".abi0")]
+	}
+	switch name {
+	case "reflect.callReflect", "reflect.makeFuncStub", "reflect.Value.call", "reflect.Value.Call", "reflect.Value.CallSlice",
+		"runtime.reflectcall", "github.com/bytedance/mockey/internal/tool.ReflectCall":
+		return true
+	}
+	if len(name) >= len("runtime.call") && name[:len("runtime.call")] == "runtime.call" {
+		suffix := name[len("runtime.call"):]
+		if suffix == "" {
+			return false
+		}
+		for _, character := range suffix {
+			if character < '0' || character > '9' {
+				return false
+			}
+		}
+		return true
+	}
+	return false
+}
+
+func (mocker *Mocker) resumeOriginal(invocation *originalInvocation, args []reflect.Value) []reflect.Value {
+	proxy := invocation.proxy
+	if proxy.Type() != mocker.builder.runtimeTargetType() {
+		// A newer generic instantiation can share the retried entry with an
+		// older layer. As in normal generic mismatch dispatch, use the current
+		// hook's ABI view of the saved proxy so its reflected results match.
+		proxy = monkeyFn.MakeFunc(mocker.builder.runtimeTargetType(), proxy.Pointer())
+	}
+	return invocation.owner.callOriginal(proxy, args)
+}

--- a/mock_original_generics_test.go
+++ b/mock_original_generics_test.go
@@ -1,0 +1,85 @@
+//go:build go1.20
+// +build go1.20
+
+/*
+ * Copyright 2026 ByteDance Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package mockey
+
+import "testing"
+
+type (
+	originalNamedInt        int
+	originalGeneric[T ~int] struct{ value T }
+)
+
+func (receiver *originalGeneric[T]) Large(value int) int {
+	var frame [65536]byte
+	frame[value&65535] = byte(value) + byte(receiver.value)
+	return originalReadFrame(&frame, value)
+}
+
+func TestOriginalSharedGenericStackGrowth(t *testing.T) {
+	var firstOriginal func(*originalGeneric[int], int) int
+	var secondOriginal func(*originalGeneric[originalNamedInt], int) int
+	firstCalls, secondCalls := 0, 0
+	firstMock := Mock((*originalGeneric[int]).Large).Origin(&firstOriginal).To(func(receiver *originalGeneric[int], value int) int {
+		firstCalls++
+		return firstOriginal(receiver, value+1)
+	}).Build()
+	defer firstMock.UnPatch()
+	secondMock := Mock((*originalGeneric[originalNamedInt]).Large).Origin(&secondOriginal).To(func(receiver *originalGeneric[originalNamedInt], value int) int {
+		secondCalls++
+		return secondOriginal(receiver, value+2)
+	}).Build()
+	defer secondMock.UnPatch()
+
+	result := make(chan int)
+	go func() { result <- (&originalGeneric[int]{}).Large(1) }()
+	if got := <-result; got != 2 || firstCalls != 1 || secondCalls != 0 || firstMock.Times() != 1 || secondMock.Times() != 0 {
+		t.Fatalf("first result=%d firstCalls=%d secondCalls=%d firstTimes=%d secondTimes=%d", got, firstCalls, secondCalls, firstMock.Times(), secondMock.Times())
+	}
+	go func() { result <- (&originalGeneric[originalNamedInt]{}).Large(1) }()
+	if got := <-result; got != 3 || firstCalls != 1 || secondCalls != 1 || firstMock.Times() != 1 || secondMock.Times() != 1 {
+		t.Fatalf("second result=%d firstCalls=%d secondCalls=%d firstTimes=%d secondTimes=%d", got, firstCalls, secondCalls, firstMock.Times(), secondMock.Times())
+	}
+}
+
+func TestOriginalStoredUnderNewerGenericLayer(t *testing.T) {
+	var firstOriginal func(*originalGeneric[int], int) int
+	firstCalls := 0
+	firstMock := Mock((*originalGeneric[int]).Large).Origin(&firstOriginal).To(func(receiver *originalGeneric[int], value int) int {
+		firstCalls++
+		return firstOriginal(receiver, value+1)
+	}).Build()
+	defer firstMock.UnPatch()
+	// Initialize Origin's captured generic dictionary before saving a call that
+	// intentionally bypasses dispatch, then install a newer shared-body layer.
+	receiver := &originalGeneric[int]{}
+	receiver.Large(0)
+	initialCalls, initialTimes := firstCalls, firstMock.Times()
+	secondCalls := 0
+	secondMock := Mock((*originalGeneric[originalNamedInt]).Large).To(func(*originalGeneric[originalNamedInt], int) int {
+		secondCalls++
+		return 999
+	}).Build()
+	defer secondMock.UnPatch()
+	result := make(chan int)
+	go func() { result <- firstOriginal(receiver, 1) }()
+	if got := <-result; got != 1 || firstCalls != initialCalls || firstMock.Times() != initialTimes || secondCalls != 0 || secondMock.Times() != 0 {
+		t.Fatalf("stored Origin result=%d firstCallDelta=%d firstTimeDelta=%d secondCalls=%d secondTimes=%d", got, firstCalls-initialCalls, firstMock.Times()-initialTimes, secondCalls, secondMock.Times())
+	}
+}

--- a/mock_original_test.go
+++ b/mock_original_test.go
@@ -1,0 +1,152 @@
+/*
+ * Copyright 2026 ByteDance Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package mockey
+
+import (
+	"bytes"
+	"reflect"
+	"testing"
+)
+
+//go:noinline
+func originalReadFrame(frame *[65536]byte, index int) int {
+	return int(frame[index&65535])
+}
+
+//go:noinline
+func originalLargeFrame(value int) int {
+	var frame [65536]byte
+	frame[value&65535] = byte(value)
+	return originalReadFrame(&frame, value)
+}
+
+func TestOriginalStackGrowth(t *testing.T) {
+	t.Run("decorator", func(t *testing.T) {
+		var original func(int) int
+		calls := 0
+		mock := Mock(originalLargeFrame).Origin(&original).To(func(value int) int {
+			calls++
+			return original(value + 1)
+		}).Build()
+		defer mock.UnPatch()
+		result := make(chan int)
+		go func() { result <- originalLargeFrame(1) }()
+		if got := <-result; got != 2 || calls != 1 || mock.Times() != 1 || mock.MockTimes() != 1 {
+			t.Fatalf("result=%d calls=%d Times=%d MockTimes=%d", got, calls, mock.Times(), mock.MockTimes())
+		}
+	})
+	t.Run("condition miss", func(t *testing.T) {
+		conditions := 0
+		mock := Mock(originalLargeFrame).When(func(int) bool {
+			conditions++
+			return false
+		}).Return(99).Build()
+		defer mock.UnPatch()
+		result := make(chan int)
+		go func() { result <- originalLargeFrame(1) }()
+		if got := <-result; got != 1 || conditions != 1 || mock.Times() != 1 || mock.MockTimes() != 0 {
+			t.Fatalf("result=%d conditions=%d Times=%d MockTimes=%d", got, conditions, mock.Times(), mock.MockTimes())
+		}
+	})
+}
+
+func originalDirectRecursive(depth int) int {
+	if depth == 0 {
+		return 0
+	}
+	return originalDirectRecursive(depth-1) + 1
+}
+
+func originalReflectRecursive(depth int) int {
+	if depth == 0 {
+		return 0
+	}
+	return int(reflect.ValueOf(originalReflectRecursive).Call([]reflect.Value{reflect.ValueOf(depth - 1)})[0].Int()) + 1
+}
+
+func TestOriginalRecursion(t *testing.T) {
+	for _, test := range []struct {
+		name   string
+		target func(int) int
+	}{
+		{"direct", originalDirectRecursive},
+		{"reflect", originalReflectRecursive},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			var original func(int) int
+			calls := 0
+			mock := Mock(test.target).Origin(&original).To(func(depth int) int {
+				calls++
+				return original(depth)
+			}).Build()
+			defer mock.UnPatch()
+			result := make(chan int)
+			go func() { result <- test.target(20) }()
+			if got := <-result; got != 20 || calls != 21 || mock.Times() != 21 || mock.MockTimes() != 21 {
+				t.Fatalf("result=%d calls=%d Times=%d MockTimes=%d", got, calls, mock.Times(), mock.MockTimes())
+			}
+		})
+	}
+}
+
+func originalNestedInner(value int) int { return value + 1 }
+func originalNestedOuter(value int) int { return originalNestedInner(value) + 1 }
+
+func TestOriginalNestedMocks(t *testing.T) {
+	var original func(int) int
+	outerCalls, innerCalls := 0, 0
+	outer := Mock(originalNestedOuter).Origin(&original).To(func(value int) int {
+		outerCalls++
+		return original(value)
+	}).Build()
+	defer outer.UnPatch()
+	inner := Mock(originalNestedInner).To(func(value int) int {
+		innerCalls++
+		return value + 10
+	}).Build()
+	defer inner.UnPatch()
+	result := make(chan int)
+	go func() { result <- originalNestedOuter(1) }()
+	if got := <-result; got != 12 || outerCalls != 1 || innerCalls != 1 || outer.Times() != 1 || inner.Times() != 1 {
+		t.Fatalf("result=%d outerCalls=%d innerCalls=%d outerTimes=%d innerTimes=%d", got, outerCalls, innerCalls, outer.Times(), inner.Times())
+	}
+}
+
+func originalCompareBytes(first, second []byte) bool {
+	return bytes.Equal(first, second)
+}
+
+func TestOriginalWithMockedBytesEqual(t *testing.T) {
+	var original func([]byte, []byte) bool
+	outer := Mock(originalCompareBytes).Origin(&original).To(func(first, second []byte) bool {
+		return original(first, second)
+	}).Build()
+	defer outer.UnPatch()
+	var equalOriginal func([]byte, []byte) bool
+	equalCalls := 0
+	equal := Mock(bytes.Equal).Origin(&equalOriginal).To(func(first, second []byte) bool {
+		equalCalls++
+		return equalOriginal(first, second)
+	}).Build()
+	defer equal.UnPatch()
+	if !originalCompareBytes([]byte("match"), []byte("match")) {
+		t.Fatal("original bytes.Equal result changed")
+	}
+	if equalCalls != 1 || equal.Times() != 1 || outer.Times() != 1 {
+		t.Fatalf("equalCalls=%d equalTimes=%d outerTimes=%d", equalCalls, equal.Times(), outer.Times())
+	}
+}

--- a/mock_test.go
+++ b/mock_test.go
@@ -1,5 +1,6 @@
 /*
  * Copyright 2022 ByteDance Inc.
+ * Modified in 2026 for Go 1.27 lint compatibility.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -221,7 +222,6 @@ func TestClass(t *testing.T) {
 				}).Build()
 				So(class{in: "abc"}.func1("xxx"), ShouldEqual, "mock")
 			})
-
 		})
 	})
 }

--- a/utils.go
+++ b/utils.go
@@ -1,5 +1,6 @@
 /*
  * Copyright 2022 ByteDance Inc.
+ * Modified in 2026 for Go 1.27 lint compatibility.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -46,7 +47,7 @@ func GetMethod(instance interface{}, methodName string, opt ...methodOptionFn) (
 
 func getMethod(val reflect.Value, methodName string, opts *methodOption) (method reflect.Value, ok bool) {
 	if !val.IsValid() {
-		return
+		return method, ok
 	}
 	typ := val.Type()
 	kind := typ.Kind()
@@ -58,7 +59,7 @@ func getMethod(val reflect.Value, methodName string, opts *methodOption) (method
 			if m, ok := typ.MethodByName(methodName); ok {
 				return m.Func, true
 			}
-			return
+			return method, ok
 		}
 		typ = val.Type()
 		kind = typ.Kind()
@@ -98,7 +99,7 @@ func getMethod(val reflect.Value, methodName string, opts *methodOption) (method
 	if m, ok := unexportedMethodByName(ptrType, methodName, opts); ok {
 		return m, true
 	}
-	return
+	return method, ok
 }
 
 // getFieldMethod gets a functional field's value as an instance
@@ -116,12 +117,12 @@ func getMethod(val reflect.Value, methodName string, opts *methodOption) (method
 // points to the anonymous function in NewFoo
 func getFieldMethod(v reflect.Value, fieldName string) (res reflect.Value, ok bool) {
 	if v.Kind() != reflect.Struct {
-		return
+		return res, ok
 	}
 
 	field := v.FieldByName(fieldName)
 	if !field.IsValid() || field.Kind() != reflect.Func {
-		return
+		return res, ok
 	}
 	return fn.MakeFunc(field.Type(), field.Pointer()), true
 }
@@ -183,11 +184,11 @@ func getNestedMethod(val reflect.Value, methodName string) (reflect.Method, bool
 // unexportedMethodByName resolve an unexported method from an instance
 func unexportedMethodByName(instanceType reflect.Type, methodName string, opts *methodOption) (res reflect.Value, ok bool) {
 	if ch0 := methodName[0]; ch0 >= 'A' && ch0 <= 'Z' {
-		return
+		return res, ok
 	}
 	typ, tfn, ok := unsafereflect.MethodByName(instanceType, methodName)
 	if !ok {
-		return
+		return res, ok
 	}
 	tool.Assert(typ != nil || opts.unexportedTargetType != nil, "failed to determine %v's type, please use `OptUnexportedTargetType` to specify", methodName)
 

--- a/utils_1_18_test.go
+++ b/utils_1_18_test.go
@@ -3,6 +3,7 @@
 
 /*
  * Copyright 2022 ByteDance Inc.
+ * Modified in 2026 to document intentional test fields for static analysis.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,6 +29,7 @@ import (
 )
 
 type testAG[T any] struct {
+	//lint:ignore U1000 Exercises non-empty generic receiver layouts.
 	t T
 	testCG[T]
 }
@@ -45,6 +47,7 @@ func (a *testAG[T]) BarC() {
 }
 
 type testBG[T any] struct {
+	//lint:ignore U1000 Exercises non-empty generic receiver layouts.
 	t T
 	*testCG[T]
 }
@@ -53,7 +56,10 @@ func (b testBG[T]) FooB() {}
 
 func (b *testBG[T]) BarB() {}
 
-type testCG[T any] struct{ t T }
+type testCG[T any] struct {
+	//lint:ignore U1000 Exercises non-empty generic receiver layouts.
+	t T
+}
 
 func (s testCG[T]) FooC() {
 	fmt.Print("")
@@ -64,6 +70,7 @@ func (s *testCG[T]) BarC() {
 }
 
 type testDG[T any] struct {
+	//lint:ignore U1000 Exercises non-empty generic receiver layouts.
 	t T
 	*testBG[T]
 }

--- a/utils_test.go
+++ b/utils_test.go
@@ -1,5 +1,6 @@
 /*
  * Copyright 2022 ByteDance Inc.
+ * Modified in 2026 for Go 1.27 lint compatibility.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -483,7 +484,7 @@ func TestGetMethod_NilPointer(t *testing.T) {
 			convey.So(obj.Foo(), convey.ShouldEqual, "nil pointer")
 		})
 		PatchConvey("nested nil pointer", func() {
-			var obj = &testNilPointerOuter{}
+			obj := &testNilPointerOuter{}
 			Mock(GetMethod(obj, "Foo")).Return("nested pointer").Build()
 			convey.So(obj.Foo(), convey.ShouldEqual, "nested pointer")
 		})


### PR DESCRIPTION
#### What type of PR is this?
feat

#### What this PR does / why we need it (en: English/zh: Chinese):
en: Support Go 1.27 core runtime, generic methods and race instrumentation; fix duplicate hook execution on original-call stack-growth retries, trampoline relocation and Windows sleep ABI. `exp/iface` remains unchanged.
zh: 适配 Go 1.27 核心功能、泛型方法及 race 检测，补充回归测试与兼容性说明。

Validation: [five-platform normal/race tests](https://github.com/Lucky-Qu/mockey/actions/runs/34219137044), [lint/static/license checks](https://github.com/Lucky-Qu/mockey/actions/runs/34219137060) and [coverage](https://github.com/Lucky-Qu/mockey/actions/runs/34219137085) pass in the fork (16 jobs). Upstream workflows await maintainer approval.

Known tradeoff: saved `Origin` calls take 22% more time serially and 7.4× in parallel (+48 B, +1 allocation/call; Go 1.25.3, macOS ARM64, GOMAXPROCS=8). Benchmarks included.

The pre-existing stack-pointer argument issue is tracked separately in #130.

#### Which issue(s) this PR fixes:
Related to Lucky-Qu/mockey#1.
