### PR TITLE
fix: preserve variadic slice arguments

### DIFF
--- a/internal/tool/reflect.go
+++ b/internal/tool/reflect.go
@@ -22,19 +22,11 @@ import (
 
 func ReflectCall(f reflect.Value, args []reflect.Value) []reflect.Value {
 	if f.Type().IsVariadic() {
-		newArgs := make([]reflect.Value, 0)
-		lastArg := args[len(args)-1]
-		for i := 0; i < len(args)-1; i++ {
-			newArgs = append(newArgs, args[i])
-		}
-
-		for i := 0; i < lastArg.Len(); i++ {
-			newArgs = append(newArgs, lastArg.Index(i))
-		}
-		return f.Call(newArgs)
-	} else {
-		return f.Call(args)
+		// MakeFunc supplies the variadic arguments as a slice. Forward it
+		// unchanged to preserve nil, capacity and the shared backing array.
+		return f.CallSlice(args)
 	}
+	return f.Call(args)
 }
 
 func NewFuncTypeByOut(ft reflect.Type, newOutTypes ...reflect.Type) reflect.Type {
@@ -57,7 +49,7 @@ func NewFuncTypeByInsertIn(ft reflect.Type, newInTypes ...reflect.Type) reflect.
 	return reflect.FuncOf(inTypes, outTypes, ft.IsVariadic())
 }
 
-func NewFuncTypeByReplaceIn(ft reflect.Type, newInType reflect.Type, newInIndex int) reflect.Type {
+func NewFuncTypeByReplaceIn(ft, newInType reflect.Type, newInIndex int) reflect.Type {
 	inTypes := make([]reflect.Type, ft.NumIn())
 	for i := 0; i < ft.NumIn(); i++ {
 		if i == newInIndex {

--- a/internal/tool/reflect_test.go
+++ b/internal/tool/reflect_test.go
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2026 ByteDance Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package tool
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestReflectCallVariadicSliceState(t *testing.T) {
+	tests := []struct {
+		name  string
+		input []int
+	}{
+		{name: "nil", input: nil},
+		{name: "empty", input: []int{}},
+		{name: "empty with capacity", input: make([]int, 0, 4)},
+		{name: "values with capacity", input: make([]int, 2, 4)},
+	}
+	f := reflect.ValueOf(func(prefix string, values ...int) (string, bool, int, int) {
+		return prefix, values == nil, len(values), cap(values)
+	})
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := ReflectCall(f, []reflect.Value{reflect.ValueOf("prefix"), reflect.ValueOf(test.input)})
+			if got[0].String() != "prefix" {
+				t.Errorf("fixed argument = %q, want prefix", got[0].String())
+			}
+			if got[1].Bool() != (test.input == nil) {
+				t.Errorf("nil = %v, want %v", got[1].Bool(), test.input == nil)
+			}
+			if got[2].Int() != int64(len(test.input)) || got[3].Int() != int64(cap(test.input)) {
+				t.Errorf("length/capacity = %d/%d, want %d/%d", got[2].Int(), got[3].Int(), len(test.input), cap(test.input))
+			}
+		})
+	}
+}
+
+func TestReflectCallVariadicSliceAliasing(t *testing.T) {
+	backing := []int{1, 2, 3, 4, 5}
+	input := backing[1:3:5]
+	f := reflect.ValueOf(func(fixed []int, values ...int) (bool, []int) {
+		values[0] = 42
+		aliased := &fixed[0] == &values[0] && fixed[0] == 42
+		return aliased, append(values, 99)
+	})
+	got := ReflectCall(f, []reflect.Value{reflect.ValueOf(input), reflect.ValueOf(input)})
+	if !got[0].Bool() {
+		t.Error("fixed and variadic arguments no longer share their backing array")
+	}
+	if want := []int{1, 42, 3, 99, 5}; !reflect.DeepEqual(backing, want) {
+		t.Errorf("caller backing array = %v, want %v", backing, want)
+	}
+	result := got[1].Interface().([]int)
+	if len(result) != 3 || cap(result) != 4 || &result[0] != &input[0] {
+		t.Errorf("returned slice = %v (len=%d cap=%d), want shared slice with len=3 cap=4", result, len(result), cap(result))
+	}
+	// Passing a slice copies its header; append must not change the caller's length.
+	if len(input) != 2 {
+		t.Errorf("caller slice length = %d, want 2", len(input))
+	}
+}
+
+func TestReflectCallNonVariadic(t *testing.T) {
+	input := []int{1, 2}
+	f := reflect.ValueOf(func(prefix string, values []int) (string, int) {
+		values[0] = 42
+		return prefix, values[1]
+	})
+	got := ReflectCall(f, []reflect.Value{reflect.ValueOf("fixed"), reflect.ValueOf(input)})
+	if got[0].String() != "fixed" || got[1].Int() != 2 || input[0] != 42 {
+		t.Errorf("non-variadic call = (%q, %d), input = %v", got[0].String(), got[1].Int(), input)
+	}
+}

--- a/mock_variadic_test.go
+++ b/mock_variadic_test.go
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2026 ByteDance Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package mockey
+
+import "testing"
+
+//go:noinline
+func variadicSliceTarget(label string, values ...int) int {
+	if len(values) == 0 {
+		return len(label)
+	}
+	return values[0]
+}
+
+//go:noinline
+func variadicSliceOriginTarget(values ...int) int {
+	values[0]++
+	return values[0]
+}
+
+// Keep the backing array on the heap so these tests isolate slice copying
+// from the separate stack-pointer relocation issue.
+//
+//go:noinline
+func variadicSliceValues() []int {
+	return make([]int, 1, 2)
+}
+
+func TestMockVariadicSliceIdentity(t *testing.T) {
+	t.Run("hook", func(t *testing.T) {
+		m := Mock(variadicSliceTarget).To(func(label string, values ...int) int {
+			values[0] = 42
+			values = append(values, len(label))
+			return values[0]
+		}).Build()
+		defer m.UnPatch()
+
+		values := variadicSliceValues()
+		got := variadicSliceTarget("label", values...)
+		if got != 42 || values[0] != 42 || values[:cap(values)][1] != 5 {
+			t.Fatalf("result=%d, backing array=%v; want 42 and [42 5]", got, values[:cap(values)])
+		}
+	})
+
+	t.Run("condition", func(t *testing.T) {
+		m := Mock(variadicSliceTarget).When(func(_ string, values ...int) bool {
+			values[0] = 41
+			return true
+		}).To(func(_ string, values ...int) int {
+			values[0]++
+			return values[0]
+		}).Build()
+		defer m.UnPatch()
+
+		values := variadicSliceValues()
+		got := variadicSliceTarget("label", values...)
+		if got != 42 || values[0] != 42 {
+			t.Fatalf("result=%d, caller value=%d; want both 42", got, values[0])
+		}
+	})
+
+	t.Run("condition miss", func(t *testing.T) {
+		m := Mock(variadicSliceTarget).When(func(_ string, values ...int) bool {
+			values[0] = 42
+			return false
+		}).Return(99).Build()
+		defer m.UnPatch()
+
+		values := variadicSliceValues()
+		got := variadicSliceTarget("label", values...)
+		if got != 42 || values[0] != 42 {
+			t.Fatalf("result=%d, caller value=%d; want both 42", got, values[0])
+		}
+	})
+
+	t.Run("origin", func(t *testing.T) {
+		var original func(...int) int
+		m := Mock(variadicSliceOriginTarget).Origin(&original).To(func(values ...int) int {
+			return original(values...)
+		}).Build()
+		defer m.UnPatch()
+
+		values := variadicSliceValues()
+		values[0] = 41
+		got := variadicSliceOriginTarget(values...)
+		if got != 42 || values[0] != 42 {
+			t.Fatalf("result=%d, caller value=%d; want both 42", got, values[0])
+		}
+	})
+}
+
+//go:noinline
+func variadicNilTarget(values ...int) bool {
+	return values == nil
+}
+
+func TestMockVariadicNilSlice(t *testing.T) {
+	m := Mock(variadicNilTarget).To(func(values ...int) bool {
+		return values == nil
+	}).Build()
+	defer m.UnPatch()
+
+	if !variadicNilTarget() {
+		t.Error("omitted variadic arguments should remain nil")
+	}
+	var nilValues []int
+	if !variadicNilTarget(nilValues...) {
+		t.Error("nil variadic arguments should remain nil")
+	}
+	if variadicNilTarget([]int{}...) {
+		t.Error("non-nil empty variadic arguments should remain non-nil")
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?
fix

#### What this PR does / why we need it (en: English/zh: Chinese):
en: Preserve variadic slices across hooks, conditions and Origin so nil state, capacity and caller-visible mutations match ordinary Go calls.
zh: 保留可变参数切片的 nil 状态、容量和共享数组，确保 mock 中的修改能传回调用方。

Validation: [native Linux AMD64 normal/race suites on Go 1.19 and 1.25](https://github.com/Lucky-Qu/mockey/actions/runs/34304986097); macOS/Linux ARM64 normal/race suites; Go 1.13/1.26 regressions; incremental lint and changed-file license checks.

#### Which issue(s) this PR fixes:
Fixes #131. Stack-pointer relocation remains tracked separately in #130.
